### PR TITLE
HUSH-269 Add snoopy's config map

### DIFF
--- a/charts/hush-sensor/Chart.yaml
+++ b/charts/hush-sensor/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: hush-sensor
 description: A Helm chart for Hush Security sensor.
 type: application
-version: 1.0.0
+version: 1.1.0
 home: https://hush.security

--- a/charts/hush-sensor/templates/_helpers.tpl
+++ b/charts/hush-sensor/templates/_helpers.tpl
@@ -6,6 +6,18 @@ Expand the name of the chart.
 {{- end }}
 
 {{/*
+Build chart full name
+*/}}
+{{- define "hush-sensor.buildChartFullName" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name }}
+    {{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+    {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this
 (by the DNS naming spec). If release name contains chart name it will be used as a
@@ -15,12 +27,7 @@ full name.
 {{- if .Values.fullnameOverride }}
     {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
-    {{- $name := default .Chart.Name .Values.nameOverride }}
-    {{- if contains $name .Release.Name }}
-        {{- .Release.Name | trunc 63 | trimSuffix "-" }}
-    {{- else }}
-        {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-    {{- end }}
+    {{- include "hush-sensor.buildChartFullName" . }}
 {{- end }}
 {{- end }}
 

--- a/charts/hush-sensor/templates/_helpers.tpl
+++ b/charts/hush-sensor/templates/_helpers.tpl
@@ -40,6 +40,13 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+Sensor config map name
+*/}}
+{{- define "hush-sensor.sensorConfigMapName" -}}
+{{- printf "%s-%s" (include "hush-sensor.buildChartFullName" .) "sensorconfigmap" }}
+{{- end }}
+
+{{/*
 Common labels
 */}}
 {{- define "hush-sensor.labels" -}}

--- a/charts/hush-sensor/templates/daemonset.yaml
+++ b/charts/hush-sensor/templates/daemonset.yaml
@@ -52,6 +52,9 @@ spec:
         - name: vector-socket
           emptyDir:
             sizeLimit: 1Mi
+        - name: sensor-config
+          configMap:
+            name: {{ include "hush-sensor.sensorConfigMapName" . }}
       containers:
         - name: hush-sensor
           image: {{ include "hush-sensor.sensorImagePath" . }}
@@ -72,6 +75,9 @@ spec:
               readOnly: true
             - name: cgroupfs
               mountPath: /hostcgroup
+              readOnly: true
+            - name: sensor-config
+              mountPath: /opt/snoopy/
               readOnly: true
         - name: hush-sensor-vector
           image: {{ include "hush-sensor.vectorImagePath" . }}

--- a/charts/hush-sensor/templates/sensorconfigmap.yaml
+++ b/charts/hush-sensor/templates/sensorconfigmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "hush-sensor.sensorConfigMapName" . }}
+  labels: {{- include "hush-sensor.labels" . | nindent 4 }}
+  namespace: {{ .Values.namespace.name }}
+data:
+  config.yaml: |
+    trace_pods_default: {{ .Values.sensorConfigMap.trace_pods_default }}
+    report_tls: {{ .Values.sensorConfigMap.report_tls }}
+    self_k8s_namespace: {{ .Values.namespace.name | quote }}

--- a/charts/hush-sensor/values.yaml
+++ b/charts/hush-sensor/values.yaml
@@ -101,3 +101,11 @@ daemonSet:
   # For more information see
   # https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
   tolerations: []
+
+sensorConfigMap:
+  # Configure pod tracing:
+  #   false = trace annotated pods only
+  #   true  = trace all pods (besides kube-system)
+  trace_pods_default: false
+  # Report TLS connections
+  report_tls: false


### PR DESCRIPTION

The ConfigMap allows customization of a subset of snoopy's configuration relevant
in Kubernetes, and passes to snoopy the actual namespace that it is deployed within.