### PR TITLE
HUSH-260 hush-sensor: templates/daemonset: Move snoopy-config to /opt/snoopy/config

### DIFF
--- a/charts/hush-sensor/templates/daemonset.yaml
+++ b/charts/hush-sensor/templates/daemonset.yaml
@@ -77,7 +77,7 @@ spec:
               mountPath: /hostcgroup
               readOnly: true
             - name: sensor-config
-              mountPath: /opt/snoopy/
+              mountPath: /opt/snoopy/config/
               readOnly: true
         - name: hush-sensor-vector
           image: {{ include "hush-sensor.vectorImagePath" . }}

--- a/charts/hush-sensor/values.yaml
+++ b/charts/hush-sensor/values.yaml
@@ -96,6 +96,7 @@ daemonSet:
               operator: In
               values:
                 - amd64
+                - arm64
 
   # A list of tolerations.
   # For more information see


### PR DESCRIPTION
Snoopy config volume must be readonly to prevent config overwrite. Therefore Location of sensor_uuid file and config.yaml should be different.