### PR TITLE
HUSH-260 hush-sensor: bump the version to 1.2.0

### DIFF
--- a/charts/hush-sensor/Chart.yaml
+++ b/charts/hush-sensor/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: hush-sensor
 description: A Helm chart for Hush Security sensor.
 type: application
-version: 1.1.0
+version: 1.2.0
 home: https://hush.security


### PR DESCRIPTION
Bumping minor as we support ARM64 now so our DaemonSet's default
affinity has changed to allow arm64 as well.
