### PR TITLE
HUSH-317 hush-sensor: change default pod tracing to "all-pods"

### DIFF
--- a/charts/hush-sensor/values.yaml
+++ b/charts/hush-sensor/values.yaml
@@ -107,6 +107,6 @@ sensorConfigMap:
   # Configure pod tracing:
   #   false = trace annotated pods only
   #   true  = trace all pods (besides kube-system)
-  trace_pods_default: false
+  trace_pods_default: true
   # Report TLS connections
   report_tls: false


### PR DESCRIPTION
We want to trace all pods in the upcoming friendly-customers release.
