### PR TITLE
HUSH-323 bump the version to 1.4.0

### DIFF
--- a/charts/hush-sensor/Chart.yaml
+++ b/charts/hush-sensor/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: hush-sensor
 description: A Helm chart for Hush Security sensor.
 type: application
-version: 1.3.0
+version: 1.4.0
 home: https://hush.security


### PR DESCRIPTION
Releasing `image.pullToken` functionality.
