### PR TITLE
HUSH-346 hush-sensor: add check of token identifiers

### DIFF
--- a/charts/hush-sensor/templates/_helpers.tpl
+++ b/charts/hush-sensor/templates/_helpers.tpl
@@ -110,12 +110,15 @@ Hush deployment info
 {{- $ctx := dict "name" "deploymentToken" "value" .Values.deploymentToken -}}
 {{- $deploymentToken := (include "hush-sensor.b64decode" $ctx) -}}
 {{- $parts := split ":" $deploymentToken -}}
-{{- $zone := trimPrefix "m" $parts._0 | trimSuffix "prd" -}}
+{{- if ne $parts._0 "d1" -}}
+    {{- fail (printf "deploymentToken version '%s' isn't supported" $parts._0) -}}
+{{- end -}}
+{{- $zone := trimPrefix "m" $parts._1 | trimSuffix "prd" -}}
 {{- $zone = ternary "" (printf "%s." $zone) (not $zone) -}}
-{{- $uri := printf "https://events.%s.%shush-security.com/v1/runtime-events" $parts._1 $zone -}}
+{{- $uri := printf "https://events.%s.%shush-security.com/v1/runtime-events" $parts._2 $zone -}}
 {{- $result := dict
-    "orgId" $parts._2
-    "deploymentId" $parts._3
+    "orgId" $parts._3
+    "deploymentId" $parts._4
     "eventReportingUri" $uri
 -}}
 {{- $result | toYaml -}}
@@ -166,7 +169,7 @@ Parse image.pullToken
     {{- $ctx := dict "name" "image.pullToken" "value" $pullToken -}}
     {{- $token := (include "hush-sensor.b64decode" $ctx) -}}
     {{- $version := splitn ":" 2 $token -}}
-    {{- if ne $version._0 "1" -}}
+    {{- if ne $version._0 "p1" -}}
         {{- fail (printf "image.pullToken version '%s' isn't supported" $version._0) -}}
     {{- end -}}
     {{- $registry := splitn ":" 2 $version._1 -}}

--- a/tests/tests/test_kubeconform.py
+++ b/tests/tests/test_kubeconform.py
@@ -1,3 +1,4 @@
+import base64
 import contextlib
 import logging
 import os
@@ -13,6 +14,7 @@ TOP_DIR = os.environ["TOP_DIR"]
 CHARTS_DIR = os.path.join(TOP_DIR, "charts")
 CHARTS = os.listdir(CHARTS_DIR)
 
+DUMMY_DEPLOYMENT_TOKEN = "d1:zone:realm:org-id:deployment-id:secret"
 KUBE_MINORS = [28, 29, 30, 31]
 KUBE_VERSION_VALUES = [f"1.{m}.0" for m in KUBE_MINORS] + ["1.29.10-eks-7f9249a"]
 HUSH_SENSOR_VALUES = [
@@ -64,7 +66,10 @@ CHART_VALUES = {"hush-sensor": HUSH_SENSOR_VALUES}
 
 
 @contextlib.contextmanager
-def values_tmp_file(values):
+def values_tmp_file(values: dict):
+    values.setdefault(
+        "deploymentToken", base64.b64encode(DUMMY_DEPLOYMENT_TOKEN.encode()).decode()
+    )
     with tempfile.NamedTemporaryFile("w+", encoding="utf-8") as tmp_file:
         dump(values, tmp_file, Dumper=Dumper)
         tmp_file.flush()


### PR DESCRIPTION
shepherd has added unique token identifiers to deployment and image-pull
tokens. Check the identifiers so that tokens cannot be mistakenly
swapped in helm chart input.
