### PR TITLE
HUSH-358 hush-sensor: map containerd directory to `/run/containerd`

### DIFF
--- a/charts/hush-sensor/templates/daemonset.yaml
+++ b/charts/hush-sensor/templates/daemonset.yaml
@@ -71,7 +71,7 @@ spec:
             - name: vector-socket
               mountPath: /tmp/vector
             - name: containerd
-              mountPath: /var/run/containerd
+              mountPath: /run/containerd
               readOnly: true
             - name: cgroupfs
               mountPath: /hostcgroup


### PR DESCRIPTION
Was `/var/run/containerd` previously.

We want this to be equal to the path on the Host.
