### PR TITLE
HUSH-366 hush-sensor: change the major version to `v0`

### DIFF
--- a/charts/hush-sensor/Chart.yaml
+++ b/charts/hush-sensor/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: hush-sensor
 description: A Helm chart for Hush Security sensor.
 type: application
-version: 1.5.0
+version: 0.5.0
 home: https://hush.security


### PR DESCRIPTION
Versions are released frequently now while many times
breaking backward compatibility.

Use `v0` major version for this stage of development.

We will bump to `v1` for the MVP release.
