### PR TITLE
HUSH-358 hush-sensor: add support for custom `criSocketPath`

### DIFF
--- a/charts/hush-sensor/templates/_helpers.tpl
+++ b/charts/hush-sensor/templates/_helpers.tpl
@@ -285,3 +285,31 @@ b64dec with error check
 {{- end -}}
 {{- printf "%s" $decoded -}}
 {{- end }}
+
+{{/*
+Validate criSocketPath
+*/}}
+{{- define "hush-sensor.criSocketPath" -}}
+{{- $path := and .Values.daemonSet .Values.daemonSet.criSocketPath -}}
+{{- if $path -}}
+    {{- if not (isAbs $path) -}}
+        {{- fail (printf "'criSocketPath' must be an absolute path: %s" $path) -}}
+    {{- end -}}
+    {{- if eq (dir $path) "/" -}}
+        {{- fail (printf "'criSocketPath' base directory cannot be root: %s" $path) -}}
+    {{- end -}}
+    {{- printf "%s" $path -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Containerd mount path
+*/}}
+{{- define "hush-sensor.containerdMountPath" -}}
+{{- $path := (include "hush-sensor.criSocketPath" .) -}}
+{{- if $path -}}
+    {{- dir $path -}}
+{{- else -}}
+    {{- printf "%s" "/run/containerd" -}}
+{{- end -}}
+{{- end }}

--- a/charts/hush-sensor/templates/daemonset.yaml
+++ b/charts/hush-sensor/templates/daemonset.yaml
@@ -43,7 +43,7 @@ spec:
       volumes:
         - name: containerd
           hostPath:
-            path: /run/containerd
+            path: {{ include "hush-sensor.containerdMountPath" . }}
             type: Directory
         - name: cgroupfs
           hostPath:
@@ -71,7 +71,7 @@ spec:
             - name: vector-socket
               mountPath: /tmp/vector
             - name: containerd
-              mountPath: /run/containerd
+              mountPath: {{ include "hush-sensor.containerdMountPath" . }}
               readOnly: true
             - name: cgroupfs
               mountPath: /hostcgroup

--- a/charts/hush-sensor/templates/daemonset.yaml
+++ b/charts/hush-sensor/templates/daemonset.yaml
@@ -55,6 +55,9 @@ spec:
         - name: sensor-config
           configMap:
             name: {{ include "hush-sensor.sensorConfigMapName" . }}
+        {{- with and .Values.daemonSet .Values.daemonSet.extraVolumes -}}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       containers:
         - name: hush-sensor
           image: {{ include "hush-sensor.sensorImagePath" . }}
@@ -79,6 +82,9 @@ spec:
             - name: sensor-config
               mountPath: /opt/snoopy/config/
               readOnly: true
+            {{- with and .Values.daemonSet .Values.daemonSet.sensorExtraVolumeMounts -}}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
         - name: hush-sensor-vector
           image: {{ include "hush-sensor.vectorImagePath" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/charts/hush-sensor/templates/sensorconfigmap.yaml
+++ b/charts/hush-sensor/templates/sensorconfigmap.yaml
@@ -13,3 +13,6 @@ data:
     org_id: {{ .orgId | quote }}
     deployment_id: {{ .deploymentId | quote }}
     {{- end }}
+    {{- with (include "hush-sensor.criSocketPath" .) }}
+    cri_socket_path: {{ . | quote }}
+    {{- end }}

--- a/charts/hush-sensor/values.yaml
+++ b/charts/hush-sensor/values.yaml
@@ -82,6 +82,12 @@ daemonSet:
   # Custom node selector
   nodeSelector: {}
 
+  # A custom CRI socket path.
+  #
+  # This must be the full socket path on the Host.
+  # Needed in cases when it cannot be auto-detected.
+  criSocketPath: ""
+
   # Additional annotations.
   # For more information see
   # https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/

--- a/charts/hush-sensor/values.yaml
+++ b/charts/hush-sensor/values.yaml
@@ -122,6 +122,12 @@ daemonSet:
   # https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
   tolerations: []
 
+  # An additional set of volumes
+  extraVolumes: []
+
+  # An additional set of mounts for sensor
+  sensorExtraVolumeMounts: []
+
 sensorConfigMap:
   # Configure pod tracing:
   #   false = trace annotated pods only


### PR DESCRIPTION
There are cases when snoopy cannot auto-detect CRI socket path.

Add support for specifying a custom path on the Host.

Map the directory of the path. This is done to allow snoopy
to reopen the socket in case it is recreated on the Host.

Pass the mounted CRI socket path to snoopy via configuration.

Allow specifying an extra set of volume mounts in sensor to allow containerd
socket directory be different from that of CRI socket.



