### PR TITLE
HUSH-361 Deployment Password separate from Token

### DIFF
--- a/charts/hush-sensor/templates/_helpers.tpl
+++ b/charts/hush-sensor/templates/_helpers.tpl
@@ -115,6 +115,17 @@ Verify deployment.token was defined
 {{- end }}
 
 {{/*
+Verify deployment.password was defined
+*/}}
+{{- define "hush-sensor.getDeploymentPassword" -}}
+{{- $password := and .Values.deployment .Values.deployment.password -}}
+{{- if not $password -}}
+    {{- fail "'deployment.password' must be defined" -}}
+{{- end -}}
+{{- printf "%s" $password -}}
+{{- end }}
+
+{{/*
 Hush deployment info
 */}}
 {{- define "hush-sensor.deploymentInfo" -}}

--- a/charts/hush-sensor/templates/_helpers.tpl
+++ b/charts/hush-sensor/templates/_helpers.tpl
@@ -264,6 +264,37 @@ PullSecret effective list
 {{- end }}
 
 {{/*
+Should we create deployment secret?
+*/}}
+{{- define "hush-sensor.shouldCreateDeploymentSecret" -}}
+{{- $keyRef := and .Values.deployment .Values.deployment.secretKeyRef -}}
+{{- $name := and $keyRef $keyRef.name -}}
+{{- $key := and $keyRef $keyRef.key -}}
+{{- if not (and $name $key) -}}
+true
+{{- end }}
+{{- end }}
+
+{{/*
+Effective deployment password secret ref
+*/}}
+{{- define "hush-sensor.effectiveDeploymentPasswordSecretRef" -}}
+{{- if (include "hush-sensor.shouldCreateDeploymentSecret" .) -}}
+    {{- dict
+        "name" (include "hush-sensor.deploymentSecretName" .)
+        "key" "deployment-password"
+        | toYaml
+    -}}
+{{- else -}}
+    {{- dict
+        "name" .Values.deployment.secretKeyRef.name
+        "key" .Values.deployment.secretKeyRef.key
+        | toYaml
+    -}}
+{{- end }}
+{{- end }}
+
+{{/*
 Build image path from components
 */}}
 {{- define "hush-sensor.buildImagePath" -}}

--- a/charts/hush-sensor/templates/_helpers.tpl
+++ b/charts/hush-sensor/templates/_helpers.tpl
@@ -104,14 +104,26 @@ type: Unconfined
 {{- end }}
 
 {{/*
+Verify deployment.token was defined
+*/}}
+{{- define "hush-sensor.getDeploymentToken" -}}
+{{- $token := and .Values.deployment .Values.deployment.token -}}
+{{- if not $token -}}
+    {{- fail "'deployment.token' must be defined" -}}
+{{- end -}}
+{{- printf "%s" $token -}}
+{{- end }}
+
+{{/*
 Hush deployment info
 */}}
 {{- define "hush-sensor.deploymentInfo" -}}
-{{- $ctx := dict "name" "deploymentToken" "value" .Values.deploymentToken -}}
+{{- $token := (include "hush-sensor.getDeploymentToken" .) -}}
+{{- $ctx := dict "name" "deployment.token" "value" $token -}}
 {{- $deploymentToken := (include "hush-sensor.b64decode" $ctx) -}}
 {{- $parts := split ":" $deploymentToken -}}
 {{- if ne $parts._0 "d1" -}}
-    {{- fail (printf "deploymentToken version '%s' isn't supported" $parts._0) -}}
+    {{- fail (printf "'deployment.token' version '%s' isn't supported" $parts._0) -}}
 {{- end -}}
 {{- $zone := trimPrefix "m" $parts._1 | trimSuffix "prd" -}}
 {{- $zone = ternary "" (printf "%s." $zone) (not $zone) -}}

--- a/charts/hush-sensor/templates/daemonset.yaml
+++ b/charts/hush-sensor/templates/daemonset.yaml
@@ -100,8 +100,10 @@ spec:
             - name: EVENT_REPORTING_DEPLOYMENT_ID
               value: {{ .deploymentId }}
             {{- end }}
+            {{- with (include "hush-sensor.effectiveDeploymentPasswordSecretRef" . | fromYaml) }}
             - name: EVENT_REPORTING_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "hush-sensor.deploymentSecretName" . }}
-                  key: deployment-password
+                  name: {{ .name }}
+                  key: {{ .key }}
+            {{- end }}

--- a/charts/hush-sensor/templates/daemonset.yaml
+++ b/charts/hush-sensor/templates/daemonset.yaml
@@ -104,4 +104,4 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "hush-sensor.deploymentSecretName" . }}
-                  key: deployment-token
+                  key: deployment-password

--- a/charts/hush-sensor/templates/deploymentsecret.yaml
+++ b/charts/hush-sensor/templates/deploymentsecret.yaml
@@ -6,4 +6,4 @@ metadata:
   labels: {{- include "hush-sensor.labels" . | nindent 4 }}
   namespace: {{ .Values.namespace.name }}
 data:
-  deployment-token: {{ .Values.deploymentToken | b64enc }}
+  deployment-token: {{ (include "hush-sensor.getDeploymentToken" .) | b64enc }}

--- a/charts/hush-sensor/templates/deploymentsecret.yaml
+++ b/charts/hush-sensor/templates/deploymentsecret.yaml
@@ -6,4 +6,4 @@ metadata:
   labels: {{- include "hush-sensor.labels" . | nindent 4 }}
   namespace: {{ .Values.namespace.name }}
 data:
-  deployment-token: {{ (include "hush-sensor.getDeploymentToken" .) | b64enc }}
+  deployment-password: {{ (include "hush-sensor.getDeploymentPassword" .) | b64enc }}

--- a/charts/hush-sensor/templates/deploymentsecret.yaml
+++ b/charts/hush-sensor/templates/deploymentsecret.yaml
@@ -1,3 +1,4 @@
+{{- if (include "hush-sensor.shouldCreateDeploymentSecret" .) -}}
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -7,3 +8,4 @@ metadata:
   namespace: {{ .Values.namespace.name }}
 data:
   deployment-password: {{ (include "hush-sensor.getDeploymentPassword" .) | b64enc }}
+{{- end }}

--- a/charts/hush-sensor/values.yaml
+++ b/charts/hush-sensor/values.yaml
@@ -22,8 +22,19 @@ namespace:
 deployment:
   # The deployment token as received from API/UI. Required.
   token: ""
-  # The deployment password as received from API/UI. Required.
+  # The deployment password as received from API/UI.
+  #
+  # When 'deployment.secretKeyRef' is defined this value is ignored.
   password: ""
+  # A reference to an existing Secret with deployment password.
+  #
+  # The secret must be defined in namespace specified in 'namespace.name'.
+  # All attributes are required.
+  secretKeyRef:
+    # Secret name
+    name: ""
+    # Secret key
+    key: ""
 
 # Values related to container images
 image:

--- a/charts/hush-sensor/values.yaml
+++ b/charts/hush-sensor/values.yaml
@@ -18,7 +18,10 @@ namespace:
   create: true
   name: "hush-security"
 
-deploymentToken: ""
+# Deployment configuration
+deployment:
+  # The deployment token as received from API/UI. Required.
+  token: ""
 
 # Values related to container images
 image:

--- a/charts/hush-sensor/values.yaml
+++ b/charts/hush-sensor/values.yaml
@@ -22,6 +22,8 @@ namespace:
 deployment:
   # The deployment token as received from API/UI. Required.
   token: ""
+  # The deployment password as received from API/UI. Required.
+  password: ""
 
 # Values related to container images
 image:

--- a/tests/tests/test_kubeconform.py
+++ b/tests/tests/test_kubeconform.py
@@ -14,7 +14,7 @@ TOP_DIR = os.environ["TOP_DIR"]
 CHARTS_DIR = os.path.join(TOP_DIR, "charts")
 CHARTS = os.listdir(CHARTS_DIR)
 
-DUMMY_DEPLOYMENT_TOKEN = "d1:zone:realm:org-id:deployment-id:secret"
+DUMMY_DEPLOYMENT_TOKEN = "d1:zone:realm:org-id:deployment-id"
 KUBE_MINORS = [28, 29, 30, 31]
 KUBE_VERSION_VALUES = [f"1.{m}.0" for m in KUBE_MINORS] + ["1.29.10-eks-7f9249a"]
 HUSH_SENSOR_VALUES = [
@@ -69,7 +69,10 @@ CHART_VALUES = {"hush-sensor": HUSH_SENSOR_VALUES}
 def values_tmp_file(values: dict):
     values.setdefault(
         "deployment",
-        {"token": base64.b64encode(DUMMY_DEPLOYMENT_TOKEN.encode()).decode()},
+        {
+            "token": base64.b64encode(DUMMY_DEPLOYMENT_TOKEN.encode()).decode(),
+            "password": "dummy_password",
+        },
     )
     with tempfile.NamedTemporaryFile("w+", encoding="utf-8") as tmp_file:
         dump(values, tmp_file, Dumper=Dumper)

--- a/tests/tests/test_kubeconform.py
+++ b/tests/tests/test_kubeconform.py
@@ -68,7 +68,8 @@ CHART_VALUES = {"hush-sensor": HUSH_SENSOR_VALUES}
 @contextlib.contextmanager
 def values_tmp_file(values: dict):
     values.setdefault(
-        "deploymentToken", base64.b64encode(DUMMY_DEPLOYMENT_TOKEN.encode()).decode()
+        "deployment",
+        {"token": base64.b64encode(DUMMY_DEPLOYMENT_TOKEN.encode()).decode()},
     )
     with tempfile.NamedTemporaryFile("w+", encoding="utf-8") as tmp_file:
         dump(values, tmp_file, Dumper=Dumper)


### PR DESCRIPTION

Deployment Token was split such that the secret value is a standalone part
called Deployment Password.

Add support for storing deployment password in external secret manager
and providing a reference to a pre-created Secret with the password. 