### PR TITLE
HUSH-422 github: remove matrix configuration

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,9 +12,7 @@ jobs:
     name: Build
     strategy:
       fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
The matix build is not really used because we build on single OS only.

Removing to simplify repository configuration in Terraform HUSH-149.
