### PR TITLE
HUSH-429 hush-sensor: rename `deployment.*` to `hushDeployment.*`

### DIFF
--- a/charts/hush-sensor/Chart.yaml
+++ b/charts/hush-sensor/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: hush-sensor
 description: A Helm chart for Hush Security sensor.
 type: application
-version: 0.7.0
+version: 0.8.0
 home: https://hush.security

--- a/charts/hush-sensor/templates/_helpers.tpl
+++ b/charts/hush-sensor/templates/_helpers.tpl
@@ -104,23 +104,23 @@ type: Unconfined
 {{- end }}
 
 {{/*
-Verify deployment.token was defined
+Verify hushDeployment.token was defined
 */}}
 {{- define "hush-sensor.getDeploymentToken" -}}
-{{- $token := and .Values.deployment .Values.deployment.token -}}
+{{- $token := and .Values.hushDeployment .Values.hushDeployment.token -}}
 {{- if not $token -}}
-    {{- fail "'deployment.token' must be defined" -}}
+    {{- fail "'hushDeployment.token' must be defined" -}}
 {{- end -}}
 {{- printf "%s" $token -}}
 {{- end }}
 
 {{/*
-Verify deployment.password was defined
+Verify hushDeployment.password was defined
 */}}
 {{- define "hush-sensor.getDeploymentPassword" -}}
-{{- $password := and .Values.deployment .Values.deployment.password -}}
+{{- $password := and .Values.hushDeployment .Values.hushDeployment.password -}}
 {{- if not $password -}}
-    {{- fail "'deployment.password' must be defined" -}}
+    {{- fail "'hushDeployment.password' must be defined" -}}
 {{- end -}}
 {{- printf "%s" $password -}}
 {{- end }}
@@ -130,11 +130,11 @@ Hush deployment info
 */}}
 {{- define "hush-sensor.deploymentInfo" -}}
 {{- $token := (include "hush-sensor.getDeploymentToken" .) -}}
-{{- $ctx := dict "name" "deployment.token" "value" $token -}}
+{{- $ctx := dict "name" "hushDeployment.token" "value" $token -}}
 {{- $deploymentToken := (include "hush-sensor.b64decode" $ctx) -}}
 {{- $parts := split ":" $deploymentToken -}}
 {{- if ne $parts._0 "d1" -}}
-    {{- fail (printf "'deployment.token' version '%s' isn't supported" $parts._0) -}}
+    {{- fail (printf "'hushDeployment.token' version '%s' isn't supported" $parts._0) -}}
 {{- end -}}
 {{- $zone := trimPrefix "m" $parts._1 | trimSuffix "prd" -}}
 {{- $zone = ternary "" (printf "%s." $zone) (not $zone) -}}
@@ -267,7 +267,7 @@ PullSecret effective list
 Should we create deployment secret?
 */}}
 {{- define "hush-sensor.shouldCreateDeploymentSecret" -}}
-{{- $keyRef := and .Values.deployment .Values.deployment.secretKeyRef -}}
+{{- $keyRef := and .Values.hushDeployment .Values.hushDeployment.secretKeyRef -}}
 {{- $name := and $keyRef $keyRef.name -}}
 {{- $key := and $keyRef $keyRef.key -}}
 {{- if not (and $name $key) -}}
@@ -287,8 +287,8 @@ Effective deployment password secret ref
     -}}
 {{- else -}}
     {{- dict
-        "name" .Values.deployment.secretKeyRef.name
-        "key" .Values.deployment.secretKeyRef.key
+        "name" .Values.hushDeployment.secretKeyRef.name
+        "key" .Values.hushDeployment.secretKeyRef.key
         | toYaml
     -}}
 {{- end }}

--- a/charts/hush-sensor/values.yaml
+++ b/charts/hush-sensor/values.yaml
@@ -18,14 +18,14 @@ namespace:
   create: true
   name: "hush-security"
 
-# Deployment configuration
-deployment:
+# Hush deployment configuration
+hushDeployment:
   # The deployment token as received from API/UI. Required.
   token: ""
 
   # The deployment password as received from API/UI.
   #
-  # When 'deployment.secretKeyRef' is defined this value is ignored.
+  # When 'hushDeployment.secretKeyRef' is defined this value is ignored.
   password: ""
 
   # A reference to an existing Secret with deployment password.

--- a/tests/tests/test_kubeconform.py
+++ b/tests/tests/test_kubeconform.py
@@ -62,7 +62,7 @@ HUSH_SENSOR_VALUES = [
         }
     },
     {
-        "deployment": {
+        "hushDeployment": {
             "secretKeyRef": {
                 "name": "pre-created-deployment-secret-name",
                 "key": "pre-created-deployment-secret-key",
@@ -75,12 +75,12 @@ CHART_VALUES = {"hush-sensor": HUSH_SENSOR_VALUES}
 
 @contextlib.contextmanager
 def values_tmp_file(values: dict):
-    deployment = values.setdefault("deployment", {})
-    deployment.setdefault(
+    hushDeployment = values.setdefault("hushDeployment", {})
+    hushDeployment.setdefault(
         "token", base64.b64encode(DUMMY_DEPLOYMENT_TOKEN.encode()).decode()
     )
-    if "secretKeyRef" not in deployment:
-        deployment.setdefault("password", "dummy_password")
+    if "secretKeyRef" not in hushDeployment:
+        hushDeployment.setdefault("password", "dummy_password")
     with tempfile.NamedTemporaryFile("w+", encoding="utf-8") as tmp_file:
         dump(values, tmp_file, Dumper=Dumper)
         tmp_file.flush()


### PR DESCRIPTION
To make it less like k8s Deployment.
