### PR TITLE
HUSH-724 hush-sensor: do not create Namespace in the chart

### DIFF
--- a/charts/hush-sensor/templates/_helpers.tpl
+++ b/charts/hush-sensor/templates/_helpers.tpl
@@ -40,6 +40,13 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+Calculate the namespace to use.
+*/}}
+{{- define "hush-sensor.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride }}
+{{- end }}
+
+{{/*
 Sensor config map name
 */}}
 {{- define "hush-sensor.sensorConfigMapName" -}}

--- a/charts/hush-sensor/templates/daemonset.yaml
+++ b/charts/hush-sensor/templates/daemonset.yaml
@@ -3,7 +3,7 @@ kind: DaemonSet
 metadata:
   name: {{ include "hush-sensor.fullName" . }}
   labels: {{- include "hush-sensor.labels" . | nindent 4 }}
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ include "hush-sensor.namespace" . }}
 
 spec:
   selector:

--- a/charts/hush-sensor/templates/deploymentsecret.yaml
+++ b/charts/hush-sensor/templates/deploymentsecret.yaml
@@ -5,7 +5,7 @@ type: Opaque
 metadata:
   name: {{ include "hush-sensor.deploymentSecretName" . }}
   labels: {{- include "hush-sensor.labels" . | nindent 4 }}
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ include "hush-sensor.namespace" . }}
 data:
   deployment-password: {{ (include "hush-sensor.getDeploymentPassword" .) | b64enc }}
 {{- end }}

--- a/charts/hush-sensor/templates/hushnamespace.yaml
+++ b/charts/hush-sensor/templates/hushnamespace.yaml
@@ -1,7 +1,0 @@
-{{- if .Values.namespace.create -}}
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .Values.namespace.name }}
-  labels: {{- include "hush-sensor.labels" . | nindent 4 }}
-{{- end }}

--- a/charts/hush-sensor/templates/imagepullsecret.yaml
+++ b/charts/hush-sensor/templates/imagepullsecret.yaml
@@ -5,7 +5,7 @@ type: kubernetes.io/dockerconfigjson
 metadata:
   name: {{ include "hush-sensor.imagePullSecretName" . }}
   labels: {{- include "hush-sensor.labels" . | nindent 4 }}
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ include "hush-sensor.namespace" . }}
 data:
   .dockerconfigjson: {{ include "hush-sensor.imagePullSecretValue" . | quote }}
 {{- end -}}

--- a/charts/hush-sensor/templates/sensorconfigmap.yaml
+++ b/charts/hush-sensor/templates/sensorconfigmap.yaml
@@ -3,13 +3,13 @@ kind: ConfigMap
 metadata:
   name: {{ include "hush-sensor.sensorConfigMapName" . }}
   labels: {{- include "hush-sensor.labels" . | nindent 4 }}
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ include "hush-sensor.namespace" . }}
 data:
   {{ $di := (include "hush-sensor.deploymentInfo" . | fromYaml) -}}
   sensor_config: |
     trace_pods_default: {{ .Values.sensorConfigMap.trace_pods_default }}
     report_tls: {{ .Values.sensorConfigMap.report_tls }}
-    self_k8s_namespace: {{ .Values.namespace.name | quote }}
+    self_k8s_namespace: {{ include "hush-sensor.namespace" . | quote }}
     org_id: {{ $di.orgId | quote }}
     deployment_id: {{ $di.deploymentId | quote }}
     {{- with (include "hush-sensor.criSocketPath" .) }}

--- a/charts/hush-sensor/values.yaml
+++ b/charts/hush-sensor/values.yaml
@@ -13,10 +13,9 @@ fullnameOverride: ""
 # https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 commonLabels: {}
 
-# The namespace for everything hush
-namespace:
-  create: true
-  name: "hush-security"
+# Override the namespace used for all objects.
+# If not specified '.Release.Namespace' is used.
+namespaceOverride: ""
 
 # Hush deployment configuration
 hushDeployment:
@@ -30,7 +29,7 @@ hushDeployment:
 
   # A reference to an existing Secret with deployment password.
   #
-  # The secret must be defined in namespace specified in 'namespace.name'.
+  # The secret must be defined in the same namespace where the chart is installed.
   # All attributes are required.
   secretKeyRef:
     # Secret name
@@ -56,7 +55,7 @@ image:
   # pullSecretList:
   #   - name: "<secret-name-here>"
   #
-  # Secrets must be pre-created in namespace specified in 'namespace.name'.
+  # Secrets must be pre-created in the same namespace where the chart is installed.
   #
   # When this list is empty 'image.pullSecret' can be used to create a secret
   # automatically.


### PR DESCRIPTION
When a chart creates its Namespace it is impossible to put the Release
object in the same namespace, becauce the namespace doesn't exist yet.

This is a downside because having everything related to some release in
the same namespace makes sense and is probably expected.

Stop creating the Namespace object. Use a pre-created namespace specified
by helm (.Release.Namespace). Allow to override the release namespace by
setting `namespaceOverride` value.

On command line the namespace can be specified as
`helm install -n <namespace-name> ...`.

UI will be updated [1] to use the helm flag accordingly.

Note that this change is not backward compatible because it requires
`helm uninstall` first, and then `helm install -n ...`.

This closes HUSH-662 as well.

[1] https://github.com/hushsecurity/mui/pull/25
