### PR TITLE
HUSH-784 hush-sensor: provide snoopy container with SELF_K8S_NAMESPACE env var

### DIFF
--- a/charts/hush-sensor/templates/daemonset.yaml
+++ b/charts/hush-sensor/templates/daemonset.yaml
@@ -88,6 +88,11 @@ spec:
             {{- with and .Values.daemonSet .Values.daemonSet.sensorExtraVolumeMounts -}}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+          env:
+            - name: SELF_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
         - name: hush-sensor-vector
           image: {{ include "hush-sensor.sensorVectorImagePath" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}


### PR DESCRIPTION

Snoopy needs to know the k8s namespace it operates in order not to track
its own processes.

So far this was passed as part of snoopy's config.yaml.

We'd like to keep snoopy config as an interface of items that allows the
admin to configure snoopy's functionalities.
The self_k8s_namespace isn't such item, it is k8s internal information.

Instead, we can pass this as an env var at the container spec using the
downward api.