### PR TITLE
HUSH-724 hush-sensor: bump the version to 0.9.0

### DIFF
--- a/charts/hush-sensor/Chart.yaml
+++ b/charts/hush-sensor/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: hush-sensor
 description: A Helm chart for Hush Security sensor.
 type: application
-version: 0.8.0
+version: 0.9.0
 home: https://hush.security


### PR DESCRIPTION
This release includes a backward incompatible change. The helm chart
doesn't create the Namespace anymore. Therefore it is required to `helm
uninstall` existing release first and then install with v0.9.0 as new
release.
