### PR TITLE
HUSH-674 Install Sentry

### DIFF
--- a/charts/hush-sensor/templates/_helpers.tpl
+++ b/charts/hush-sensor/templates/_helpers.tpl
@@ -32,6 +32,13 @@ full name.
 {{- end }}
 
 {{/*
+Create a default fully qualified app name for Sentry.
+*/}}
+{{- define "hush-sensor.sentryFullName" -}}
+{{- printf "%s-sentry" (include "hush-sensor.fullName" .) | trunc 63 }}
+{{- end }}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "hush-sensor.chart" -}}
@@ -331,6 +338,18 @@ Vector image path
 {{- $ctx := dict
     "registry" (include "hush-sensor.imageRegistry" .)
     "repository" .Values.image.sensorVectorRepository
+    "tag" .Values.image.sensorTag
+-}}
+{{- include "hush-sensor.buildImagePath" $ctx -}}
+{{- end }}
+{{/*
+
+Sentry image path
+*/}}
+{{- define "hush-sensor.sentryImagePath" -}}
+{{- $ctx := dict
+    "registry" (include "hush-sensor.imageRegistry" .)
+    "repository" .Values.image.sentryRepository
     "tag" .Values.image.sensorTag
 -}}
 {{- include "hush-sensor.buildImagePath" $ctx -}}

--- a/charts/hush-sensor/templates/sentryclusterrole.yaml
+++ b/charts/hush-sensor/templates/sentryclusterrole.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.sentry.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "hush-sensor.sentryFullName" . }}
+  labels: {{- include "hush-sensor.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+{{- end -}}

--- a/charts/hush-sensor/templates/sentryclusterrolebinding.yaml
+++ b/charts/hush-sensor/templates/sentryclusterrolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.sentry.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "hush-sensor.sentryFullName" . }}
+  labels: {{- include "hush-sensor.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "hush-sensor.sentryFullName" . }}
+  namespace: {{ include "hush-sensor.namespace" . }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "hush-sensor.sentryFullName" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/charts/hush-sensor/templates/sentrydeployment.yaml
+++ b/charts/hush-sensor/templates/sentrydeployment.yaml
@@ -1,0 +1,103 @@
+{{- if .Values.sentry.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "hush-sensor.sentryFullName" . }}
+  labels: {{- include "hush-sensor.labels" . | nindent 4 }}
+  namespace: {{ include "hush-sensor.namespace" . }}
+
+spec:
+  selector:
+    matchLabels: {{- include "hush-sensor.selectorLabels" . | nindent 6 }}
+  {{- with .Values.sentry.strategy }}
+  strategy: {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+  template:
+    metadata:
+      labels: {{- include "hush-sensor.labels" . | nindent 8 }}
+      {{ with .Values.sentry.annotations -}}
+      annotations: {{- . | nindent 8 }}
+      {{- end }}
+
+    spec:
+      {{- with .Values.sentry.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- with .Values.sentry.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.sentry.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.sentry.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      dnsPolicy: ClusterFirstWithHostNet
+      restartPolicy: Always
+      {{- with (include "hush-sensor.imagePullSecretEffectiveList" .) }}
+      imagePullSecrets: {{- . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.sentry.terminationGracePeriodSeconds }}
+      serviceAccountName: {{ include "hush-sensor.sentryFullName" . }}
+      volumes:
+        - name: vector-socket
+          emptyDir:
+            sizeLimit: 1Mi
+        - name: sensor-config
+          configMap:
+            name: {{ include "hush-sensor.sensorConfigMapName" . }}
+            items:
+              - key: sensor_config
+                path: config.yaml
+        {{- with and .Values.sentry .Values.sentry.extraVolumes -}}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      containers:
+        - name: hush-sentry
+          image: {{ include "hush-sensor.sentryImagePath" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          volumeMounts:
+            - name: vector-socket
+              mountPath: /tmp/vector
+            - name: sensor-config
+              mountPath: /opt/pluto/config/
+              readOnly: true
+            {{- with and .Values.sentry .Values.sentry.sentryExtraVolumeMounts -}}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+          env:
+            - name: SELF_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+        - name: hush-sentry-vector
+          image: {{ include "hush-sensor.sensorVectorImagePath" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          volumeMounts:
+            - name: vector-socket
+              mountPath: /tmp/vector
+          env:
+            - name: EVENT_REPORTING_ENDPOINT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "hush-sensor.sensorConfigMapName" . }}
+                  key: event_reporting_uri
+            - name: EVENT_REPORTING_ORG_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "hush-sensor.sensorConfigMapName" . }}
+                  key: org_id
+            - name: EVENT_REPORTING_DEPLOYMENT_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "hush-sensor.sensorConfigMapName" . }}
+                  key: deployment_id
+            {{- with (include "hush-sensor.effectiveDeploymentPasswordSecretRef" . | fromYaml) }}
+            - name: EVENT_REPORTING_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .name }}
+                  key: {{ .key }}
+            {{- end }}
+{{- end -}}

--- a/charts/hush-sensor/templates/sentryserviceaccount.yaml
+++ b/charts/hush-sensor/templates/sentryserviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.sentry.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "hush-sensor.sentryFullName" . }}
+  labels: {{- include "hush-sensor.labels" . | nindent 4 }}
+  namespace: {{ include "hush-sensor.namespace" . }}
+{{- end -}}

--- a/charts/hush-sensor/values.yaml
+++ b/charts/hush-sensor/values.yaml
@@ -94,6 +94,9 @@ image:
   # The repository used for sensor-vector
   sensorVectorRepository: sensor-vector
 
+  # The repository used for sentry
+  sentryRepository: sentry
+
 daemonSet:
   # Custom priority class
   priorityClassName: ""
@@ -154,3 +157,55 @@ sensorConfigMap:
   trace_pods_default: true
   # Report TLS connections
   report_tls: false
+
+sentry:
+  # Hush Security Sentry monitors k8s secrets usage as volumes/envvars in pods
+  #    true  = Deploy the Sentry pod as part of the Sensor installation
+  #    false = Do not deploy the Sentry pod
+  enabled: true
+
+  # Custom priority class
+  priorityClassName: ""
+
+  # Custom node selector
+  nodeSelector: {}
+
+  # Additional annotations.
+  # For more information see
+  # https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  annotations: {}
+
+  # Termination grace period
+  terminationGracePeriodSeconds: 30
+
+  # An update strategy
+  strategy:
+    type: RollingUpdate
+
+  # Node affinity.
+  # Choose the node types by OS and Arch.
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+            - key: kubernetes.io/os
+              operator: In
+              values:
+                - linux
+            - key: kubernetes.io/arch
+              operator: In
+              values:
+                - amd64
+                - arm64
+
+  # A list of tolerations.
+  # For more information see
+  # https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+  tolerations: []
+
+  # An additional set of volumes
+  extraVolumes: []
+
+  # An additional set of mounts for sentry
+  sentryExtraVolumeMounts: []


### PR DESCRIPTION
Install everything required for Sentry to discover k8s secrets shared
with containers as volumes/envvars.
Set sentry.enabled=false to skip Sentry installation.
