### PR TITLE
HUSH-777 github: use fixed linear issue for dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,5 @@ updates:
     directory: /
     schedule:
       interval: daily
+    commit-message:
+      prefix: "HUSH-777 "


### PR DESCRIPTION
Otherwise Capataz fails the build.
