### PR TITLE
HUSH-1136 hush-sensor: add `hostDir` value

### DIFF
--- a/charts/hush-sensor/templates/daemonset.yaml
+++ b/charts/hush-sensor/templates/daemonset.yaml
@@ -58,6 +58,10 @@ spec:
             items:
               - key: sensor_config
                 path: config.yaml
+        - name: host-dir
+          hostPath:
+            path: {{ .Values.hostDir }}
+            type: DirectoryOrCreate
         {{- with and .Values.daemonSet .Values.daemonSet.extraVolumes -}}
           {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -85,6 +89,8 @@ spec:
             - name: sensor-config
               mountPath: /opt/snoopy/config/
               readOnly: true
+            - name: host-dir
+              mountPath: /var/lib/hush-security
             {{- with and .Values.daemonSet .Values.daemonSet.sensorExtraVolumeMounts -}}
               {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/hush-sensor/templates/sentrydeployment.yaml
+++ b/charts/hush-sensor/templates/sentrydeployment.yaml
@@ -50,6 +50,10 @@ spec:
             items:
               - key: sensor_config
                 path: config.yaml
+        - name: host-dir
+          hostPath:
+            path: {{ .Values.hostDir }}
+            type: DirectoryOrCreate
         {{- with and .Values.sentry .Values.sentry.extraVolumes -}}
           {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -63,6 +67,8 @@ spec:
             - name: sensor-config
               mountPath: /opt/pluto/config/
               readOnly: true
+            - name: host-dir
+              mountPath: /var/lib/hush-security
             {{- with and .Values.sentry .Values.sentry.sentryExtraVolumeMounts -}}
               {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/hush-sensor/values.yaml
+++ b/charts/hush-sensor/values.yaml
@@ -13,6 +13,9 @@ fullnameOverride: ""
 # https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 commonLabels: {}
 
+# Host directory for minimal caching
+hostDir: "/var/lib/hush-security"
+
 # Override the namespace used for all objects.
 # If not specified '.Release.Namespace' is used.
 namespaceOverride: ""


### PR DESCRIPTION
`hostDir` defines a directory on host that should be mounted in Hush
daemons. This is used as a semi-persistent cache for identifier files
like agent UUID etc.
