### PR TITLE
HUSH-1031 hush-sensor: disable vermon by default

### DIFF
--- a/charts/hush-sensor/values.yaml
+++ b/charts/hush-sensor/values.yaml
@@ -224,7 +224,7 @@ vermon:
   # for this feature to perform as expected.
   #    true  = Deploy the Vermon pod as part of the Sensor installation
   #    false = Do not deploy the Vermon pod
-  enabled: true
+  enabled: false
 
   # How often to check for channel updates, in go time.Duration format
   # Minimum 4 hours, maximum 360 hours (15 days)


### PR DESCRIPTION
Will be enabled back in a separate commit.
