### PR TITLE
HUSH-1376 tests: remove `--no-update` option from `poetry lock`

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -22,7 +22,7 @@ endif
 default: lint
 
 poetry.lock: pyproject.toml
-	@poetry lock --no-update
+	@poetry lock
 
 .venv: poetry.lock
 	@poetry $(__INSTALL_CMD) --with ci


### PR DESCRIPTION
This was missed in commit 47fe3a0fe8.
