### PR TITLE
HUSH-1376 cli: remove `--no-update` option from `poetry lock`

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -9,7 +9,7 @@ endif
 default: lint
 
 poetry.lock: pyproject.toml
-	@poetry lock --no-update
+	@poetry lock
 	@touch $@
 
 .venv: poetry.lock


### PR DESCRIPTION
This was missed in commit 47fe3a0fe8.
