### PR TITLE
HUSH-1416 hush-sensor: support configuring EVENT_REPORTING_CONSOLE vector env

### DIFF
--- a/charts/hush-sensor/templates/daemonset.yaml
+++ b/charts/hush-sensor/templates/daemonset.yaml
@@ -161,3 +161,10 @@ spec:
                   name: {{ .name }}
                   key: {{ .key }}
             {{- end }}
+            {{- if .Values.eventReportingConsole }}
+            - name: EVENT_REPORTING_CONSOLE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "hush-sensor.sensorConfigMapName" . }}
+                  key: event_reporting_console
+            {{- end }}

--- a/charts/hush-sensor/templates/sensorconfigmap.yaml
+++ b/charts/hush-sensor/templates/sensorconfigmap.yaml
@@ -24,3 +24,4 @@ data:
   channel_digests_uri: {{ $di.channelDigestsUri | quote }}
   org_id: {{ $di.orgId | quote }}
   deployment_id: {{ $di.deploymentId | quote }}
+  event_reporting_console: {{ .Values.eventReportingConsole | quote }}

--- a/charts/hush-sensor/templates/sentrydeployment.yaml
+++ b/charts/hush-sensor/templates/sentrydeployment.yaml
@@ -139,4 +139,11 @@ spec:
                   name: {{ .name }}
                   key: {{ .key }}
             {{- end }}
+            {{- if .Values.eventReportingConsole }}
+            - name: EVENT_REPORTING_CONSOLE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "hush-sensor.sensorConfigMapName" . }}
+                  key: event_reporting_console
+            {{- end }}
 {{- end -}}

--- a/charts/hush-sensor/templates/vermondeployment.yaml
+++ b/charts/hush-sensor/templates/vermondeployment.yaml
@@ -150,4 +150,11 @@ spec:
                   name: {{ .name }}
                   key: {{ .key }}
             {{- end }}
+            {{- if .Values.eventReportingConsole }}
+            - name: EVENT_REPORTING_CONSOLE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "hush-sensor.sensorConfigMapName" . }}
+                  key: event_reporting_console
+            {{- end }}
 {{- end -}}

--- a/charts/hush-sensor/values.yaml
+++ b/charts/hush-sensor/values.yaml
@@ -20,6 +20,12 @@ hostDir: "/var/lib/hush-security"
 # If not specified '.Release.Namespace' is used.
 namespaceOverride: ""
 
+# Mode of event logging:
+# - "yes"       - log everything (may be high volume)
+# - "no"        - log nothing
+# - "heartbeat" - log heartbeat events only (low volume)
+eventReportingConsole: "heartbeat"
+
 # Hush deployment configuration
 hushDeployment:
   # The deployment token as received from API/UI. Required.


### PR DESCRIPTION
1. Add a new value `eventReportingConsole` and corresponding ConfigMap
   entry `event_reporting_console`.
2. Map `event_reporting_console` into all vectors' env if value is
   non-empty string.
