### PR TITLE
HUSH-777 cli: fix formatting error

### DIFF
--- a/cli/cli/charts.py
+++ b/cli/cli/charts.py
@@ -34,7 +34,7 @@ def add_release_annotation(chart_name, chart_data):
             f"cannot add release annotation: annotations already exist {ants}"
         )
     with open(chart_path(chart_name), "a", encoding="utf-8") as f:
-        lines = ["annotations:\n" f'  security.hush/release: "{RELEASE}"\n']
+        lines = ["annotations:\n", f'  security.hush/release: "{RELEASE}"\n']
         f.writelines(lines)
         f.flush()
     bash("git diff")


### PR DESCRIPTION
The forgotten comma isn't a bug because it yields a single string with
two lines. However, in new ruff versions it yields formatting error [1].

Add the forgotten comma to avoid formatting mismatch.

[1]

1 file would be reformatted, 5 files already formatted
--- cli/charts.py
+++ cli/charts.py
@@ -34,7 +34,7 @@
             f"cannot add release annotation: annotations already exist {ants}"
         )
     with open(chart_path(chart_name), "a", encoding="utf-8") as f:
-        lines = ["annotations:\n" f'  security.hush/release: "{RELEASE}"\n']
+        lines = [f'annotations:\n  security.hush/release: "{RELEASE}"\n']
         f.writelines(lines)
         f.flush()
     bash("git diff")

make[1]: *** [Makefile:25: rufflint] Error 1
