### PR TITLE
HUSH-1031 hush-sensor: enable vermon

### DIFF
--- a/charts/hush-sensor/values.yaml
+++ b/charts/hush-sensor/values.yaml
@@ -266,7 +266,7 @@ vermon:
   # for this feature to perform as expected.
   #    true  = Deploy the Vermon pod as part of the Sensor installation
   #    false = Do not deploy the Vermon pod
-  enabled: false
+  enabled: true
 
   # How often to check for channel updates, in go time.Duration format
   # Minimum 4 hours, maximum 360 hours (15 days)


### PR DESCRIPTION

Revert "HUSH-1031 hush-sensor: disable vermon by default"

This reverts commit 4eca013856e5cb389c27bdc29a7b733b79112271.
