### PR TITLE
HUSH-1562 hush-sensor: pass more k8s information into vector env

### DIFF
--- a/charts/hush-sensor/templates/_helpers.tpl
+++ b/charts/hush-sensor/templates/_helpers.tpl
@@ -420,3 +420,12 @@ Containerd mount path
     {{- printf "%s" "/run/containerd" -}}
 {{- end -}}
 {{- end }}
+
+{{/*
+kubeSystemUid returns a stable cluster identifier
+that is also easy to retrieve with Helm.
+*/}}
+{{- define "hush-sensor.kubeSystemUid" -}}
+{{- $ks := lookup "v1" "Namespace" "" "kube-system" -}}
+{{- and $ks.metadata $ks.metadata.uid -}}
+{{- end }}

--- a/charts/hush-sensor/templates/daemonset.yaml
+++ b/charts/hush-sensor/templates/daemonset.yaml
@@ -168,3 +168,9 @@ spec:
                   name: {{ include "hush-sensor.sensorConfigMapName" . }}
                   key: event_reporting_console
             {{- end }}
+            - name: KUBE_SYSTEM_UID
+              value: {{ include "hush-sensor.kubeSystemUid" . }}
+            - name: HELM_RELEASE
+              value: {{ .Release.Name }}
+            - name: HELM_NAMESPACE
+              value: {{ include "hush-sensor.namespace" . }}

--- a/charts/hush-sensor/templates/sentrydeployment.yaml
+++ b/charts/hush-sensor/templates/sentrydeployment.yaml
@@ -146,4 +146,10 @@ spec:
                   name: {{ include "hush-sensor.sensorConfigMapName" . }}
                   key: event_reporting_console
             {{- end }}
+            - name: KUBE_SYSTEM_UID
+              value: {{ include "hush-sensor.kubeSystemUid" . }}
+            - name: HELM_RELEASE
+              value: {{ .Release.Name }}
+            - name: HELM_NAMESPACE
+              value: {{ include "hush-sensor.namespace" . }}
 {{- end -}}

--- a/charts/hush-sensor/templates/vermondeployment.yaml
+++ b/charts/hush-sensor/templates/vermondeployment.yaml
@@ -157,4 +157,10 @@ spec:
                   name: {{ include "hush-sensor.sensorConfigMapName" . }}
                   key: event_reporting_console
             {{- end }}
+            - name: KUBE_SYSTEM_UID
+              value: {{ include "hush-sensor.kubeSystemUid" . }}
+            - name: HELM_RELEASE
+              value: {{ .Release.Name }}
+            - name: HELM_NAMESPACE
+              value: {{ include "hush-sensor.namespace" . }}
 {{- end -}}


### PR DESCRIPTION
To be reported in heartbeat events. This will help us better understand
customer deployments and possibly alert on misconfigurations.

The `kube-system` namespace is predefined in k8s clusters, therefore it
is very convenient to use its UID as a stable cluster identifier because:

(a) it is unlikely to be deleted or recreated
(b) Helm provides us the `lookup` function to query Namespace
    attributes, so it can be retrieved easily unlike the real Cluster ID
