### PR TITLE
HUSH-1754 Custom annotations for sentry service account

### DIFF
--- a/charts/hush-sensor/ci/sentry-service-account-annotations-values.yaml
+++ b/charts/hush-sensor/ci/sentry-service-account-annotations-values.yaml
@@ -1,0 +1,9 @@
+---
+hushDeployment:
+  token: "ZDE6em9uZTpyZWFsbTpvcmctaWQ6ZGVwbG95bWVudC1pZA=="
+  password: "koko.password"
+
+sentry:
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: "arn:aws:iam::000000000000:role/sentry-iam-role"

--- a/charts/hush-sensor/templates/sentryserviceaccount.yaml
+++ b/charts/hush-sensor/templates/sentryserviceaccount.yaml
@@ -5,4 +5,7 @@ metadata:
   name: {{ include "hush-sensor.sentryFullName" . }}
   labels: {{- include "hush-sensor.labels" . | nindent 4 }}
   namespace: {{ include "hush-sensor.namespace" . }}
+  {{ with and .Values.sentry.serviceAccount .Values.sentry.serviceAccount.annotations -}}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
 {{- end -}}

--- a/charts/hush-sensor/values.yaml
+++ b/charts/hush-sensor/values.yaml
@@ -260,6 +260,11 @@ sentry:
       cpu: "10m"
       memory: "32Mi"
 
+  # Customizations for sentry service account
+  serviceAccount:
+    # Custom annotations for sentry service account
+    annotations: {}
+
 vermon:
   # Hush Security Vermon keeps hush sensor channel images up to date.
   # Hush Sensor containers must be deployed with image pull policy "Always"


### PR DESCRIPTION

This is needed to allow AWS IRSA integration to get sentry access to AWS Secret Manager.

[1] https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html