### PR TITLE
HUSH-1295 hush-sensor: allow sentry read ConfigMaps

### DIFF
--- a/charts/hush-sensor/templates/sentryclusterrole.yaml
+++ b/charts/hush-sensor/templates/sentryclusterrole.yaml
@@ -9,6 +9,6 @@ rules:
     resources: ["pods"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
-    resources: ["secrets"]
+    resources: ["secrets", "configmaps"]
     verbs: ["get"]
 {{- end -}}


### PR DESCRIPTION
Needed to generate Origin events for env vars mapped from ConfigMaps.
