### PR TITLE
HUSH-1295 hush-sensor: enable `SENTRY_SCAN_CONFIG_MAPS` feature gate

### DIFF
--- a/charts/hush-sensor/templates/sentrydeployment.yaml
+++ b/charts/hush-sensor/templates/sentrydeployment.yaml
@@ -102,6 +102,8 @@ spec:
                   name: {{ .name }}
                   key: {{ .key }}
             {{- end }}
+            - name: SENTRY_SCAN_CONFIG_MAPS
+              value: "1"
         - name: hush-sentry-vector
           image: {{ include "hush-sensor.sensorVectorImagePath" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}


### PR DESCRIPTION
This is to notify sentry that required permissions are set to read
ConfigMaps.

Sentry needs this new env var to enable ConfigMaps scanning.

The permissions were set in commit 591f990c4c.
