### PR TITLE
HUSH-1834 hush-sensor: add a catch-all toleration to all services

### DIFF
--- a/charts/hush-sensor/values.yaml
+++ b/charts/hush-sensor/values.yaml
@@ -160,9 +160,11 @@ daemonSet:
                 - fargate
 
   # A list of tolerations.
+  # Match all taints by default.
   # For more information see
   # https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-  tolerations: []
+  tolerations:
+    - operator: "Exists"
 
   # An additional set of volumes
   extraVolumes: []
@@ -240,9 +242,11 @@ sentry:
                 - arm64
 
   # A list of tolerations.
+  # Match all taints by default.
   # For more information see
   # https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-  tolerations: []
+  tolerations:
+    - operator: "Exists"
 
   # An additional set of volumes
   extraVolumes: []
@@ -321,9 +325,11 @@ vermon:
                 - arm64
 
   # A list of tolerations.
+  # Match all taints by default.
   # For more information see
   # https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-  tolerations: []
+  tolerations:
+    - operator: "Exists"
 
   # An additional set of volumes
   extraVolumes: []

--- a/charts/hush-sensor/values.yaml
+++ b/charts/hush-sensor/values.yaml
@@ -150,6 +150,14 @@ daemonSet:
               values:
                 - amd64
                 - arm64
+            - key: type
+              operator: NotIn
+              values:
+                - virtual-kubelet
+            - key: eks.amazonaws.com/compute-type
+              operator: NotIn
+              values:
+                - fargate
 
   # A list of tolerations.
   # For more information see


### PR DESCRIPTION
There are deployments where nodes are managed in pools grouped by
taints (e.g. karpenter). In such deployments our default settings allow
hush-sensor to run only on non-pool nodes (those without taints).

Add a catch-all toleration to all pods in the chart.

Add well-known node types (like Fargate and Azure Virtual Nodes) to anti-affinity rules to avoid running on them even though tolerations allow it.
