### PR TITLE
HUSH-1848 charts/hush-sensor: generate sentry crawler configuration for aws

### DIFF
--- a/charts/hush-sensor/ci/sentry-service-account-annotations-values.yaml
+++ b/charts/hush-sensor/ci/sentry-service-account-annotations-values.yaml
@@ -6,4 +6,7 @@ hushDeployment:
 sentry:
   serviceAccount:
     annotations:
-      eks.amazonaws.com/role-arn: "arn:aws:iam::000000000000:role/sentry-iam-role"
+      anotherannotation: "testing"
+  creds:
+    aws:
+      irsa: "arn:aws:iam::000000000000:role/sentry-iam-role"

--- a/charts/hush-sensor/templates/sensorconfigmap.yaml
+++ b/charts/hush-sensor/templates/sensorconfigmap.yaml
@@ -25,3 +25,15 @@ data:
   org_id: {{ $di.orgId | quote }}
   deployment_id: {{ $di.deploymentId | quote }}
   event_reporting_console: {{ .Values.eventReportingConsole | quote }}
+  sentry_config: |
+    trace_pods_default: {{ .Values.sensorConfigMap.trace_pods_default }}
+    self_k8s_namespace: {{ include "hush-sensor.namespace" . | quote }}
+    org_id: {{ $di.orgId | quote }}
+    deployment_id: {{ $di.deploymentId | quote }}
+    {{- with .Values.sentry.creds }}
+    creds:
+    {{- if and .aws .aws.irsa }}
+      aws:
+        enabled: true
+    {{- end }}
+    {{- end }}

--- a/charts/hush-sensor/templates/sentrydeployment.yaml
+++ b/charts/hush-sensor/templates/sentrydeployment.yaml
@@ -48,7 +48,7 @@ spec:
           configMap:
             name: {{ include "hush-sensor.sensorConfigMapName" . }}
             items:
-              - key: sensor_config
+              - key: sentry_config
                 path: config.yaml
         - name: host-dir
           hostPath:

--- a/charts/hush-sensor/templates/sentryserviceaccount.yaml
+++ b/charts/hush-sensor/templates/sentryserviceaccount.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "hush-sensor.sentryFullName" . }}
   labels: {{- include "hush-sensor.labels" . | nindent 4 }}
   namespace: {{ include "hush-sensor.namespace" . }}
-  {{ with and .Values.sentry.serviceAccount .Values.sentry.serviceAccount.annotations -}}
-  annotations: {{ toYaml . | nindent 4 }}
+  {{- with (include "hush-sensor.sentryServiceAccountAnnotations" .) }}
+  annotations: {{- . | nindent 4 }}
   {{- end }}
-{{- end -}}
+{{- end }}

--- a/charts/hush-sensor/values.yaml
+++ b/charts/hush-sensor/values.yaml
@@ -277,6 +277,13 @@ sentry:
     # Custom annotations for sentry service account
     annotations: {}
 
+  # Credentials for sentry secret store crawler
+  # aws:
+  #   irsa: arn of role to configure with irsa annotations
+  creds:
+    aws:
+      irsa: ""
+
 vermon:
   # Hush Security Vermon keeps hush sensor channel images up to date.
   # Hush Sensor containers must be deployed with image pull policy "Always"


### PR DESCRIPTION
Add AWS authentication configuration for the Sentry crawler with three modes:

- "irsa": Enables AWS IAM Roles for Service Accounts on EKS clusters by:
  * Adding role-arn annotation to the Sentry service account
  * Setting crawler AWS configuration to use "default" authentication mode

- "assume_role": Reserved for future implementation of role assumption on non-EKS clusters (functionality not yet implemented)

- "" (empty): Disables AWS crawler functionality while preserving other crawler configurations

This change includes:
- New crawler configuration in the sensor ConfigMap
- Updated mounting of crawler configuration in Sentry deployment
- Structured AWS options in values.yaml
- Migration from annotation-based to mode-based configuration