### PR TITLE
HUSH-1796 hush-sensor: support storing deployment token in k8s Secret

### DIFF
--- a/charts/hush-sensor/Chart.yaml
+++ b/charts/hush-sensor/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: hush-sensor
 description: A Helm chart for Hush Security sensor.
 type: application
-version: 0.19.0
+version: 0.20.0
 home: https://hush.security

--- a/charts/hush-sensor/values.yaml
+++ b/charts/hush-sensor/values.yaml
@@ -28,23 +28,33 @@ eventReportingConsole: "heartbeat"
 
 # Hush deployment configuration
 hushDeployment:
-  # The deployment token as received from API/UI. Required.
+  # The deployment token as received from API/UI.
+  #
+  # When 'hushDeployment.secretKeyRef.{name,tokenKey}' are defined this value is ignored.
+  # Otherwise this value is required.
   token: ""
 
   # The deployment password as received from API/UI.
   #
-  # When 'hushDeployment.secretKeyRef' is defined this value is ignored.
+  # When 'hushDeployment.secretKeyRef.{name,key}' are defined this value is ignored.
+  # Otherwise this value is required.
   password: ""
 
-  # A reference to an existing Secret with deployment password.
+  # A reference to an existing Secret with deployment password and token.
   #
   # The secret must be defined in the same namespace where the chart is installed.
-  # All attributes are required.
+  #
+  # If deployment token is stored this way updating its value in the Secret
+  # must be followed by chart recompilation (helm upgrade/template) or
+  # fresh installation (helm install).
   secretKeyRef:
     # Secret name
     name: ""
-    # Secret key
+    # Password secret key
     key: ""
+    # Token secret key
+    tokenKey: ""
+
 
 # Values related to container images
 image:


### PR DESCRIPTION
Add support for storing deployment token next to deployment password
in the same k8s Secret.
