### PR TITLE
HUSH-2108 Stop using the `lookup` Helm function

### DIFF
--- a/charts/hush-sensor/templates/_helpers.tpl
+++ b/charts/hush-sensor/templates/_helpers.tpl
@@ -165,7 +165,7 @@ Verify hushDeployment.token was defined
 {{/*
 Verify hushDeployment.password was defined
 */}}
-{{- define "hush-sensor.getDeploymentPassword" -}}
+{{- define "hush-sensor.getDeploymentPasswordValue" -}}
 {{- $password := and .Values.hushDeployment .Values.hushDeployment.password -}}
 {{- if not $password -}}
     {{- fail "'hushDeployment.password' is undefined" -}}

--- a/charts/hush-sensor/templates/connectordeployment.yaml
+++ b/charts/hush-sensor/templates/connectordeployment.yaml
@@ -50,18 +50,20 @@ spec:
           volumeMounts: {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
-            {{- with (include "hush-sensor.effectiveDeploymentPasswordSecretRef" . | fromYaml) }}
-            - name: DEPLOYMENT_PASSWORD
+            {{- with (include "hush-sensor.effectiveDeploymentTokenSecretRef" . | fromYaml) }}
+            - name: HUSH_DEPLOYMENT_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ .name }}
                   key: {{ .key }}
             {{- end }}
-            - name: CONNECTOR_FQDN
+            {{- with (include "hush-sensor.effectiveDeploymentPasswordSecretRef" . | fromYaml) }}
+            - name: HUSH_DEPLOYMENT_PASSWORD
               valueFrom:
-                configMapKeyRef:
-                  name: {{ include "hush-sensor.sensorConfigMapName" . }}
-                  key: connector_fqdn
+                secretKeyRef:
+                  name: {{ .name }}
+                  key: {{ .key }}
+            {{- end }}
             {{- with and .Values.connector .Values.connector.connectorClientRetryMaxBackoff }}
             - name: RETRY_MAX_BACKOFF
               value: {{ . | quote }}

--- a/charts/hush-sensor/templates/daemonset.yaml
+++ b/charts/hush-sensor/templates/daemonset.yaml
@@ -104,23 +104,15 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: LOG_CONFIG_ENDPOINT
+            {{- with (include "hush-sensor.effectiveDeploymentTokenSecretRef" . | fromYaml) }}
+            - name: HUSH_DEPLOYMENT_TOKEN
               valueFrom:
-                configMapKeyRef:
-                  name: {{ include "hush-sensor.sensorConfigMapName" . }}
-                  key: log_config_uri
-            - name: EVENT_REPORTING_ORG_ID
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "hush-sensor.sensorConfigMapName" . }}
-                  key: org_id
-            - name: EVENT_REPORTING_DEPLOYMENT_ID
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "hush-sensor.sensorConfigMapName" . }}
-                  key: deployment_id
+                secretKeyRef:
+                  name: {{ .name }}
+                  key: {{ .key }}
+            {{- end }}
             {{- with (include "hush-sensor.effectiveDeploymentPasswordSecretRef" . | fromYaml) }}
-            - name: EVENT_REPORTING_TOKEN
+            - name: HUSH_DEPLOYMENT_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ .name }}
@@ -136,28 +128,15 @@ spec:
             - name: vector-socket
               mountPath: /tmp/vector
           env:
-            - name: EVENT_REPORTING_ENDPOINT
+            {{- with (include "hush-sensor.effectiveDeploymentTokenSecretRef" . | fromYaml) }}
+            - name: HUSH_DEPLOYMENT_TOKEN
               valueFrom:
-                configMapKeyRef:
-                  name: {{ include "hush-sensor.sensorConfigMapName" . }}
-                  key: event_reporting_uri
-            - name: LOG_REPORTING_ENDPOINT
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "hush-sensor.sensorConfigMapName" . }}
-                  key: log_reporting_uri
-            - name: EVENT_REPORTING_ORG_ID
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "hush-sensor.sensorConfigMapName" . }}
-                  key: org_id
-            - name: EVENT_REPORTING_DEPLOYMENT_ID
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "hush-sensor.sensorConfigMapName" . }}
-                  key: deployment_id
+                secretKeyRef:
+                  name: {{ .name }}
+                  key: {{ .key }}
+            {{- end }}
             {{- with (include "hush-sensor.effectiveDeploymentPasswordSecretRef" . | fromYaml) }}
-            - name: EVENT_REPORTING_TOKEN
+            - name: HUSH_DEPLOYMENT_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ .name }}

--- a/charts/hush-sensor/templates/daemonset.yaml
+++ b/charts/hush-sensor/templates/daemonset.yaml
@@ -41,6 +41,7 @@ spec:
       imagePullSecrets: {{- . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.daemonSet.terminationGracePeriodSeconds }}
+      serviceAccountName: {{ include "hush-sensor.fullName" . }}
       volumes:
         - name: cri
           hostPath:

--- a/charts/hush-sensor/templates/daemonsetclusterrole.yaml
+++ b/charts/hush-sensor/templates/daemonsetclusterrole.yaml
@@ -1,0 +1,11 @@
+{{- if include "hush-sensor.shouldCreateDaemonSet" . -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "hush-sensor.fullName" . }}
+  labels: {{- include "hush-sensor.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list"]
+{{- end }}

--- a/charts/hush-sensor/templates/daemonsetclusterrolebinding.yaml
+++ b/charts/hush-sensor/templates/daemonsetclusterrolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if include "hush-sensor.shouldCreateDaemonSet" . -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "hush-sensor.fullName" . }}
+  labels: {{- include "hush-sensor.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "hush-sensor.fullName" . }}
+    namespace: {{ include "hush-sensor.namespace" . }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "hush-sensor.fullName" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/hush-sensor/templates/daemonsetserviceaccount.yaml
+++ b/charts/hush-sensor/templates/daemonsetserviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if include "hush-sensor.shouldCreateDaemonSet" . -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "hush-sensor.fullName" . }}
+  labels: {{- include "hush-sensor.labels" . | nindent 4 }}
+  namespace: {{ include "hush-sensor.namespace" . }}
+{{- end }}

--- a/charts/hush-sensor/templates/deploymentsecret.yaml
+++ b/charts/hush-sensor/templates/deploymentsecret.yaml
@@ -7,5 +7,5 @@ metadata:
   labels: {{- include "hush-sensor.labels" . | nindent 4 }}
   namespace: {{ include "hush-sensor.namespace" . }}
 data:
-  deployment-password: {{ (include "hush-sensor.getDeploymentPassword" .) | b64enc }}
+  deployment-password: {{ (include "hush-sensor.getDeploymentPasswordValue" .) | b64enc }}
 {{- end }}

--- a/charts/hush-sensor/templates/deploymentsecret.yaml
+++ b/charts/hush-sensor/templates/deploymentsecret.yaml
@@ -7,5 +7,10 @@ metadata:
   labels: {{- include "hush-sensor.labels" . | nindent 4 }}
   namespace: {{ include "hush-sensor.namespace" . }}
 data:
+  {{- if (include "hush-sensor.shouldCreateDeploymentTokenSecret" .) }}
+  deployment-token: {{ (include "hush-sensor.getDeploymentTokenValue" .) | b64enc }}
+  {{- end }}
+  {{- if (include "hush-sensor.shouldCreateDeploymentPasswordSecret" .) }}
   deployment-password: {{ (include "hush-sensor.getDeploymentPasswordValue" .) | b64enc }}
+  {{- end }}
 {{- end }}

--- a/charts/hush-sensor/templates/sensorconfigmap.yaml
+++ b/charts/hush-sensor/templates/sensorconfigmap.yaml
@@ -5,31 +5,20 @@ metadata:
   labels: {{- include "hush-sensor.labels" . | nindent 4 }}
   namespace: {{ include "hush-sensor.namespace" . }}
 data:
-  {{ $di := (include "hush-sensor.deploymentInfo" . | fromYaml) -}}
   sensor_config: |
     trace_pods_default: {{ .Values.sensorConfigMap.trace_pods_default }}
     report_tls: {{ .Values.sensorConfigMap.report_tls }}
     self_k8s_namespace: {{ include "hush-sensor.namespace" . | quote }}
-    org_id: {{ $di.orgId | quote }}
-    deployment_id: {{ $di.deploymentId | quote }}
     {{- with (include "hush-sensor.criSocketPath" .) }}
     cri_socket_path: {{ . | quote }}
     {{- end }}
     {{- with .Values.sensorConfigMap.akeyless_gateway_domain }}
     akeyless_gateway_domain: {{ . | quote }}
     {{- end }}
-  event_reporting_uri: {{ $di.eventReportingUri | quote }}
-  log_reporting_uri: {{ $di.logReportingUri | quote }}
-  log_config_uri: {{ $di.logConfigUri | quote }}
-  channel_digests_uri: {{ $di.channelDigestsUri | quote }}
-  org_id: {{ $di.orgId | quote }}
-  deployment_id: {{ $di.deploymentId | quote }}
   event_reporting_console: {{ .Values.eventReportingConsole | quote }}
   sentry_config: |
     trace_pods_default: {{ .Values.sensorConfigMap.trace_pods_default }}
     self_k8s_namespace: {{ include "hush-sensor.namespace" . | quote }}
-    org_id: {{ $di.orgId | quote }}
-    deployment_id: {{ $di.deploymentId | quote }}
     {{- with .Values.sentry.integrations }}
     integrations:
     {{- if and .aws (or .aws.irsa  .aws.assume_role_arn) }}
@@ -40,4 +29,3 @@ data:
         {{- end }}
     {{- end }}
     {{- end }}
-  connector_fqdn: {{ $di.connectorFqdn | quote }}

--- a/charts/hush-sensor/templates/vermonclusterrole.yaml
+++ b/charts/hush-sensor/templates/vermonclusterrole.yaml
@@ -14,4 +14,7 @@ rules:
   - apiGroups: ["apps"]
     resources: ["daemonsets", "deployments"]
     verbs: ["patch"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list"]
 {{- end -}}

--- a/charts/hush-sensor/templates/vermonclusterrole.yaml
+++ b/charts/hush-sensor/templates/vermonclusterrole.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.vermon.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: {{ include "hush-sensor.vermonFullName" . }}
   labels: {{- include "hush-sensor.labels" . | nindent 4 }}

--- a/charts/hush-sensor/templates/vermonclusterrolebinding.yaml
+++ b/charts/hush-sensor/templates/vermonclusterrolebinding.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.vermon.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: {{ include "hush-sensor.vermonFullName" . }}
   labels: {{- include "hush-sensor.labels" . | nindent 4 }}
@@ -9,7 +9,7 @@ subjects:
   name: {{ include "hush-sensor.vermonFullName" . }}
   namespace: {{ include "hush-sensor.namespace" . }}
 roleRef:
-  kind: Role
+  kind: ClusterRole
   name: {{ include "hush-sensor.vermonFullName" . }}
   apiGroup: rbac.authorization.k8s.io
 {{- end -}}


### PR DESCRIPTION
`lookup` cannot be used in some environments (e.g. `argocd`).

Stop using `lookup`. Consequently, stop parsing deployment 
token in Helm. When user provides a reference to a pre-created 
Secret with deployment token/password we do not see the value.
Hence, as we do not use `lookup` anymore, we cannot parse it.

Generation of configuration items based on deployment token
atoms is responsibility of Pods now.