### PR TITLE
HUSH-2108 Stop using `lookup` function

### DIFF
--- a/charts/hush-sensor/templates/_helpers.tpl
+++ b/charts/hush-sensor/templates/_helpers.tpl
@@ -165,7 +165,7 @@ Verify hushDeployment.token was defined
 {{/*
 Verify hushDeployment.password was defined
 */}}
-{{- define "hush-sensor.getDeploymentPassword" -}}
+{{- define "hush-sensor.getDeploymentPasswordValue" -}}
 {{- $password := and .Values.hushDeployment .Values.hushDeployment.password -}}
 {{- if not $password -}}
     {{- fail "'hushDeployment.password' is undefined" -}}

--- a/charts/hush-sensor/templates/_helpers.tpl
+++ b/charts/hush-sensor/templates/_helpers.tpl
@@ -134,32 +134,12 @@ type: Unconfined
 {{/*
 Verify hushDeployment.token was defined
 */}}
-{{- define "hush-sensor.getDeploymentToken" -}}
-{{- $keyRef := and .Values.hushDeployment .Values.hushDeployment.secretKeyRef -}}
-{{- $secretName := and $keyRef $keyRef.name -}}
-{{- $secretKey := and $keyRef $keyRef.tokenKey -}}
-{{- if and $secretName $secretKey -}}
-    {{- $namespace := (include "hush-sensor.namespace" .) -}}
-    {{- $secret := lookup "v1" "Secret" $namespace $secretName -}}
-    {{- if not $secret -}}
-        {{- fail (printf "failed to lookup Secret=%s in Namespace=%s (hushDeployment.secretKeyRef.name)" $secretName $namespace) -}}
-    {{- else -}}
-        {{- $tokenB64 := (dig "data" $secretKey "<missing>" $secret) -}}
-        {{- if eq $tokenB64 "<missing>" -}}
-            {{- fail (printf "deployment token Key=%s is missing in Secret=%s (hushDeployment.secretKeyRef.tokenKey)" $secretKey $secretName) -}}
-        {{- else -}}
-            {{- $token := b64dec $tokenB64 -}}
-            {{- printf "%s" $token -}}
-        {{- end -}}
-    {{- end -}}
-{{- else -}}
-    {{- $token := and .Values.hushDeployment .Values.hushDeployment.token -}}
-    {{- if not $token -}}
-        {{- fail "'hushDeployment.token' is undefined" -}}
-    {{- else -}}
-        {{- printf "%s" $token -}}
-    {{- end -}}
+{{- define "hush-sensor.getDeploymentTokenValue" -}}
+{{- $token := and .Values.hushDeployment .Values.hushDeployment.token -}}
+{{- if not $token -}}
+    {{- fail "'hushDeployment.token' is undefined" -}}
 {{- end -}}
+{{- printf "%s" $token -}}
 {{- end }}
 
 {{/*
@@ -171,39 +151,6 @@ Verify hushDeployment.password was defined
     {{- fail "'hushDeployment.password' is undefined" -}}
 {{- end -}}
 {{- printf "%s" $password -}}
-{{- end }}
-
-{{/*
-Hush deployment info
-*/}}
-{{- define "hush-sensor.deploymentInfo" -}}
-{{- $token := (include "hush-sensor.getDeploymentToken" .) -}}
-{{- $ctx := dict "name" "hushDeployment.token" "value" $token -}}
-{{- $deploymentToken := (include "hush-sensor.b64decode" $ctx) -}}
-{{- $parts := split ":" $deploymentToken -}}
-{{- if ne $parts._0 "d1" -}}
-    {{- fail (printf "'hushDeployment.token' version '%s' isn't supported" $parts._0) -}}
-{{- end -}}
-{{- $zone := trimPrefix "m" $parts._1 | trimSuffix "prd" -}}
-{{- $zone = ternary "" (printf "%s." $zone) (not $zone) -}}
-{{- $baseFqdn := printf "%s.%shush-security.com" $parts._2 $zone -}}
-{{- $baseUri := printf "https://events.%s/v1" $baseFqdn -}}
-{{- $eventsUri := printf "%s/runtime-events" $baseUri -}}
-{{- $logsUri := printf "%s/runtime-logs" $baseUri -}}
-{{- $logsConfigUri := printf "%s/runtime-logs-config" $baseUri -}}
-{{- $registry := (include "hush-sensor.imageRegistry" .) -}}
-{{- $channelDigestsUri := printf "%s/runtime-versions?registry=%s" $baseUri $registry -}}
-{{- $connectorFqdn := printf "%s.ab.%s" $parts._4 $baseFqdn -}}
-{{- $result := dict
-    "orgId" $parts._3
-    "deploymentId" $parts._4
-    "eventReportingUri" $eventsUri
-    "logReportingUri" $logsUri
-    "logConfigUri" $logsConfigUri
-    "channelDigestsUri" $channelDigestsUri
-    "connectorFqdn" $connectorFqdn
--}}
-{{- $result | toYaml -}}
 {{- end }}
 
 {{/*
@@ -333,14 +280,56 @@ PullSecret effective list
 {{- end }}
 
 {{/*
-Should we create deployment secret?
+Should we create the deployment token secret?
 */}}
-{{- define "hush-sensor.shouldCreateDeploymentSecret" -}}
+{{- define "hush-sensor.shouldCreateDeploymentTokenSecret" -}}
+{{- $keyRef := and .Values.hushDeployment .Values.hushDeployment.secretKeyRef -}}
+{{- $name := and $keyRef $keyRef.name -}}
+{{- $tokenKey := and $keyRef $keyRef.tokenKey -}}
+{{- if not (and $name $tokenKey) -}}
+true
+{{- end }}
+{{- end }}
+
+{{/*
+Should we create the deployment password secret?
+*/}}
+{{- define "hush-sensor.shouldCreateDeploymentPasswordSecret" -}}
 {{- $keyRef := and .Values.hushDeployment .Values.hushDeployment.secretKeyRef -}}
 {{- $name := and $keyRef $keyRef.name -}}
 {{- $key := and $keyRef $keyRef.key -}}
 {{- if not (and $name $key) -}}
 true
+{{- end }}
+{{- end }}
+
+{{/*
+Should we create deployment secret?
+*/}}
+{{- define "hush-sensor.shouldCreateDeploymentSecret" -}}
+{{- if or
+    (include "hush-sensor.shouldCreateDeploymentTokenSecret" .)
+    (include "hush-sensor.shouldCreateDeploymentPasswordSecret" .) -}}
+true
+{{- end -}}
+{{- end }}
+
+{{/*
+Effective deployment token secret ref
+*/}}
+{{- define "hush-sensor.effectiveDeploymentTokenSecretRef" -}}
+{{- if (include "hush-sensor.shouldCreateDeploymentTokenSecret" .) -}}
+    {{- dict
+        "name" (include "hush-sensor.deploymentSecretName" .)
+        "key" "deployment-token"
+        | toYaml
+    -}}
+{{- else -}}
+    {{- dict
+        "name" .Values.hushDeployment.secretKeyRef.name
+        "key" .Values.hushDeployment.secretKeyRef.tokenKey
+        | toYaml
+    -}}
 {{- end }}
 {{- end }}
 
@@ -486,15 +475,6 @@ Containerd mount path
 {{- end }}
 
 {{/*
-kubeSystemUid returns a stable cluster identifier
-that is also easy to retrieve with Helm.
-*/}}
-{{- define "hush-sensor.kubeSystemUid" -}}
-{{- $ks := lookup "v1" "Namespace" "" "kube-system" -}}
-{{- and $ks.metadata $ks.metadata.uid -}}
-{{- end }}
-
-{{/* 
 Sentry service account annotations with AWS IAM role handling
 */}}
 {{- define "hush-sensor.sentryServiceAccountAnnotations" -}}

--- a/charts/hush-sensor/templates/connectorclusterrole.yaml
+++ b/charts/hush-sensor/templates/connectorclusterrole.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.connector.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "hush-sensor.connectorFullName" . }}
+  labels: {{- include "hush-sensor.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get"]
+{{- end }}

--- a/charts/hush-sensor/templates/connectorclusterrolebinding.yaml
+++ b/charts/hush-sensor/templates/connectorclusterrolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.connector.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "hush-sensor.connectorFullName" . }}
+  labels: {{- include "hush-sensor.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "hush-sensor.connectorFullName" . }}
+    namespace: {{ include "hush-sensor.namespace" . }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "hush-sensor.connectorFullName" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/hush-sensor/templates/connectordeployment.yaml
+++ b/charts/hush-sensor/templates/connectordeployment.yaml
@@ -39,6 +39,7 @@ spec:
       imagePullSecrets: {{- . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.connector.terminationGracePeriodSeconds }}
+      serviceAccountName: {{ include "hush-sensor.connectorFullName" . }}
       containers:
         - name: hush-connector-client
           image: {{ include "hush-sensor.connectorClientImagePath" . }}

--- a/charts/hush-sensor/templates/connectordeployment.yaml
+++ b/charts/hush-sensor/templates/connectordeployment.yaml
@@ -51,6 +51,13 @@ spec:
           volumeMounts: {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
+            {{- with (include "hush-sensor.effectiveDeploymentTokenSecretRef" . | fromYaml) }}
+            - name: DEPLOYMENT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .name }}
+                  key: {{ .key }}
+            {{- end }}
             {{- with (include "hush-sensor.effectiveDeploymentPasswordSecretRef" . | fromYaml) }}
             - name: DEPLOYMENT_PASSWORD
               valueFrom:
@@ -58,11 +65,6 @@ spec:
                   name: {{ .name }}
                   key: {{ .key }}
             {{- end }}
-            - name: CONNECTOR_FQDN
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "hush-sensor.sensorConfigMapName" . }}
-                  key: connector_fqdn
             {{- with and .Values.connector .Values.connector.connectorClientRetryMaxBackoff }}
             - name: RETRY_MAX_BACKOFF
               value: {{ . | quote }}
@@ -76,9 +78,23 @@ spec:
           {{- with and .Values.connector .Values.connector.forwarderExtraVolumeMounts }}
           volumeMounts: {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.connector.forwarderTimeout }}
           env:
+            {{- with (include "hush-sensor.effectiveDeploymentTokenSecretRef" . | fromYaml) }}
+            - name: DEPLOYMENT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .name }}
+                  key: {{ .key }}
+            {{- end }}
+            {{- with (include "hush-sensor.effectiveDeploymentPasswordSecretRef" . | fromYaml) }}
+            - name: DEPLOYMENT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .name }}
+                  key: {{ .key }}
+            {{- end }}
+            {{- with .Values.connector.forwarderTimeout }}
             - name: FORWARDER_TIMEOUT
               value: {{ . | quote }}
-          {{- end }}
+            {{- end }}
 {{- end -}}

--- a/charts/hush-sensor/templates/connectordeployment.yaml
+++ b/charts/hush-sensor/templates/connectordeployment.yaml
@@ -65,6 +65,8 @@ spec:
                   name: {{ .name }}
                   key: {{ .key }}
             {{- end }}
+            - name: DEPLOYMENT_KIND
+              value: k8s
             {{- with and .Values.connector .Values.connector.connectorClientRetryMaxBackoff }}
             - name: RETRY_MAX_BACKOFF
               value: {{ . | quote }}
@@ -93,6 +95,8 @@ spec:
                   name: {{ .name }}
                   key: {{ .key }}
             {{- end }}
+            - name: DEPLOYMENT_KIND
+              value: k8s
             {{- with .Values.connector.forwarderTimeout }}
             - name: FORWARDER_TIMEOUT
               value: {{ . | quote }}

--- a/charts/hush-sensor/templates/connectorserviceaccount.yaml
+++ b/charts/hush-sensor/templates/connectorserviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.connector.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "hush-sensor.connectorFullName" . }}
+  labels: {{- include "hush-sensor.labels" . | nindent 4 }}
+  namespace: {{ include "hush-sensor.namespace" . }}
+{{- end }}

--- a/charts/hush-sensor/templates/daemonset.yaml
+++ b/charts/hush-sensor/templates/daemonset.yaml
@@ -118,6 +118,8 @@ spec:
                   name: {{ .name }}
                   key: {{ .key }}
             {{- end }}
+            - name: DEPLOYMENT_KIND
+              value: k8s
         - name: hush-sensor-vector
           image: {{ include "hush-sensor.sensorVectorImagePath" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -142,6 +144,8 @@ spec:
                   name: {{ .name }}
                   key: {{ .key }}
             {{- end }}
+            - name: DEPLOYMENT_KIND
+              value: k8s
             {{- if .Values.eventReportingConsole }}
             - name: EVENT_REPORTING_CONSOLE
               valueFrom:

--- a/charts/hush-sensor/templates/daemonset.yaml
+++ b/charts/hush-sensor/templates/daemonset.yaml
@@ -104,23 +104,15 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: LOG_CONFIG_ENDPOINT
+            {{- with (include "hush-sensor.effectiveDeploymentTokenSecretRef" . | fromYaml) }}
+            - name: DEPLOYMENT_TOKEN
               valueFrom:
-                configMapKeyRef:
-                  name: {{ include "hush-sensor.sensorConfigMapName" . }}
-                  key: log_config_uri
-            - name: EVENT_REPORTING_ORG_ID
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "hush-sensor.sensorConfigMapName" . }}
-                  key: org_id
-            - name: EVENT_REPORTING_DEPLOYMENT_ID
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "hush-sensor.sensorConfigMapName" . }}
-                  key: deployment_id
+                secretKeyRef:
+                  name: {{ .name }}
+                  key: {{ .key }}
+            {{- end }}
             {{- with (include "hush-sensor.effectiveDeploymentPasswordSecretRef" . | fromYaml) }}
-            - name: EVENT_REPORTING_TOKEN
+            - name: DEPLOYMENT_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ .name }}
@@ -136,28 +128,15 @@ spec:
             - name: vector-socket
               mountPath: /tmp/vector
           env:
-            - name: EVENT_REPORTING_ENDPOINT
+            {{- with (include "hush-sensor.effectiveDeploymentTokenSecretRef" . | fromYaml) }}
+            - name: DEPLOYMENT_TOKEN
               valueFrom:
-                configMapKeyRef:
-                  name: {{ include "hush-sensor.sensorConfigMapName" . }}
-                  key: event_reporting_uri
-            - name: LOG_REPORTING_ENDPOINT
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "hush-sensor.sensorConfigMapName" . }}
-                  key: log_reporting_uri
-            - name: EVENT_REPORTING_ORG_ID
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "hush-sensor.sensorConfigMapName" . }}
-                  key: org_id
-            - name: EVENT_REPORTING_DEPLOYMENT_ID
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "hush-sensor.sensorConfigMapName" . }}
-                  key: deployment_id
+                secretKeyRef:
+                  name: {{ .name }}
+                  key: {{ .key }}
+            {{- end }}
             {{- with (include "hush-sensor.effectiveDeploymentPasswordSecretRef" . | fromYaml) }}
-            - name: EVENT_REPORTING_TOKEN
+            - name: DEPLOYMENT_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ .name }}
@@ -170,8 +149,6 @@ spec:
                   name: {{ include "hush-sensor.sensorConfigMapName" . }}
                   key: event_reporting_console
             {{- end }}
-            - name: KUBE_SYSTEM_UID
-              value: {{ include "hush-sensor.kubeSystemUid" . }}
             - name: HELM_RELEASE
               value: {{ .Release.Name }}
             - name: HELM_NAMESPACE

--- a/charts/hush-sensor/templates/daemonset.yaml
+++ b/charts/hush-sensor/templates/daemonset.yaml
@@ -41,6 +41,7 @@ spec:
       imagePullSecrets: {{- . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.daemonSet.terminationGracePeriodSeconds }}
+      serviceAccountName: {{ include "hush-sensor.fullName" . }}
       volumes:
         - name: cri
           hostPath:

--- a/charts/hush-sensor/templates/daemonsetclusterrole.yaml
+++ b/charts/hush-sensor/templates/daemonsetclusterrole.yaml
@@ -1,0 +1,11 @@
+{{- if include "hush-sensor.shouldCreateDaemonSet" . -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "hush-sensor.fullName" . }}
+  labels: {{- include "hush-sensor.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get"]
+{{- end }}

--- a/charts/hush-sensor/templates/daemonsetclusterrolebinding.yaml
+++ b/charts/hush-sensor/templates/daemonsetclusterrolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if include "hush-sensor.shouldCreateDaemonSet" . -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "hush-sensor.fullName" . }}
+  labels: {{- include "hush-sensor.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "hush-sensor.fullName" . }}
+    namespace: {{ include "hush-sensor.namespace" . }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "hush-sensor.fullName" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/hush-sensor/templates/daemonsetserviceaccount.yaml
+++ b/charts/hush-sensor/templates/daemonsetserviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if include "hush-sensor.shouldCreateDaemonSet" . -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "hush-sensor.fullName" . }}
+  labels: {{- include "hush-sensor.labels" . | nindent 4 }}
+  namespace: {{ include "hush-sensor.namespace" . }}
+{{- end }}

--- a/charts/hush-sensor/templates/deploymentsecret.yaml
+++ b/charts/hush-sensor/templates/deploymentsecret.yaml
@@ -7,5 +7,5 @@ metadata:
   labels: {{- include "hush-sensor.labels" . | nindent 4 }}
   namespace: {{ include "hush-sensor.namespace" . }}
 data:
-  deployment-password: {{ (include "hush-sensor.getDeploymentPassword" .) | b64enc }}
+  deployment-password: {{ (include "hush-sensor.getDeploymentPasswordValue" .) | b64enc }}
 {{- end }}

--- a/charts/hush-sensor/templates/deploymentsecret.yaml
+++ b/charts/hush-sensor/templates/deploymentsecret.yaml
@@ -7,5 +7,10 @@ metadata:
   labels: {{- include "hush-sensor.labels" . | nindent 4 }}
   namespace: {{ include "hush-sensor.namespace" . }}
 data:
+  {{- if (include "hush-sensor.shouldCreateDeploymentTokenSecret" .) }}
+  deployment-token: {{ (include "hush-sensor.getDeploymentTokenValue" .) | b64enc }}
+  {{- end }}
+  {{- if (include "hush-sensor.shouldCreateDeploymentPasswordSecret" .) }}
   deployment-password: {{ (include "hush-sensor.getDeploymentPasswordValue" .) | b64enc }}
+  {{- end }}
 {{- end }}

--- a/charts/hush-sensor/templates/sensorconfigmap.yaml
+++ b/charts/hush-sensor/templates/sensorconfigmap.yaml
@@ -5,31 +5,20 @@ metadata:
   labels: {{- include "hush-sensor.labels" . | nindent 4 }}
   namespace: {{ include "hush-sensor.namespace" . }}
 data:
-  {{ $di := (include "hush-sensor.deploymentInfo" . | fromYaml) -}}
   sensor_config: |
     trace_pods_default: {{ .Values.sensorConfigMap.trace_pods_default }}
     report_tls: {{ .Values.sensorConfigMap.report_tls }}
     self_k8s_namespace: {{ include "hush-sensor.namespace" . | quote }}
-    org_id: {{ $di.orgId | quote }}
-    deployment_id: {{ $di.deploymentId | quote }}
     {{- with (include "hush-sensor.criSocketPath" .) }}
     cri_socket_path: {{ . | quote }}
     {{- end }}
     {{- with .Values.sensorConfigMap.akeyless_gateway_domain }}
     akeyless_gateway_domain: {{ . | quote }}
     {{- end }}
-  event_reporting_uri: {{ $di.eventReportingUri | quote }}
-  log_reporting_uri: {{ $di.logReportingUri | quote }}
-  log_config_uri: {{ $di.logConfigUri | quote }}
-  channel_digests_uri: {{ $di.channelDigestsUri | quote }}
-  org_id: {{ $di.orgId | quote }}
-  deployment_id: {{ $di.deploymentId | quote }}
   event_reporting_console: {{ .Values.eventReportingConsole | quote }}
   sentry_config: |
     trace_pods_default: {{ .Values.sensorConfigMap.trace_pods_default }}
     self_k8s_namespace: {{ include "hush-sensor.namespace" . | quote }}
-    org_id: {{ $di.orgId | quote }}
-    deployment_id: {{ $di.deploymentId | quote }}
     {{- with .Values.sentry.integrations }}
     integrations:
     {{- if and .aws (or .aws.irsa  .aws.assume_role_arn) }}
@@ -40,4 +29,3 @@ data:
         {{- end }}
     {{- end }}
     {{- end }}
-  connector_fqdn: {{ $di.connectorFqdn | quote }}

--- a/charts/hush-sensor/templates/sentrydeployment.yaml
+++ b/charts/hush-sensor/templates/sentrydeployment.yaml
@@ -80,23 +80,15 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: LOG_CONFIG_ENDPOINT
+            {{- with (include "hush-sensor.effectiveDeploymentTokenSecretRef" . | fromYaml) }}
+            - name: DEPLOYMENT_TOKEN
               valueFrom:
-                configMapKeyRef:
-                  name: {{ include "hush-sensor.sensorConfigMapName" . }}
-                  key: log_config_uri
-            - name: EVENT_REPORTING_ORG_ID
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "hush-sensor.sensorConfigMapName" . }}
-                  key: org_id
-            - name: EVENT_REPORTING_DEPLOYMENT_ID
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "hush-sensor.sensorConfigMapName" . }}
-                  key: deployment_id
+                secretKeyRef:
+                  name: {{ .name }}
+                  key: {{ .key }}
+            {{- end }}
             {{- with (include "hush-sensor.effectiveDeploymentPasswordSecretRef" . | fromYaml) }}
-            - name: EVENT_REPORTING_TOKEN
+            - name: DEPLOYMENT_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ .name }}
@@ -106,8 +98,6 @@ spec:
               value: "1"
             - name: PLUTO_CRAWL_K8S_SECRETSTORE
               value: "1"
-            - name: KUBE_SYSTEM_UID
-              value: {{ include "hush-sensor.kubeSystemUid" . }}
         - name: hush-sentry-vector
           image: {{ include "hush-sensor.sensorVectorImagePath" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -118,28 +108,15 @@ spec:
             - name: vector-socket
               mountPath: /tmp/vector
           env:
-            - name: EVENT_REPORTING_ENDPOINT
+            {{- with (include "hush-sensor.effectiveDeploymentTokenSecretRef" . | fromYaml) }}
+            - name: DEPLOYMENT_TOKEN
               valueFrom:
-                configMapKeyRef:
-                  name: {{ include "hush-sensor.sensorConfigMapName" . }}
-                  key: event_reporting_uri
-            - name: LOG_REPORTING_ENDPOINT
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "hush-sensor.sensorConfigMapName" . }}
-                  key: log_reporting_uri
-            - name: EVENT_REPORTING_ORG_ID
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "hush-sensor.sensorConfigMapName" . }}
-                  key: org_id
-            - name: EVENT_REPORTING_DEPLOYMENT_ID
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "hush-sensor.sensorConfigMapName" . }}
-                  key: deployment_id
+                secretKeyRef:
+                  name: {{ .name }}
+                  key: {{ .key }}
+            {{- end }}
             {{- with (include "hush-sensor.effectiveDeploymentPasswordSecretRef" . | fromYaml) }}
-            - name: EVENT_REPORTING_TOKEN
+            - name: DEPLOYMENT_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ .name }}
@@ -152,8 +129,6 @@ spec:
                   name: {{ include "hush-sensor.sensorConfigMapName" . }}
                   key: event_reporting_console
             {{- end }}
-            - name: KUBE_SYSTEM_UID
-              value: {{ include "hush-sensor.kubeSystemUid" . }}
             - name: HELM_RELEASE
               value: {{ .Release.Name }}
             - name: HELM_NAMESPACE

--- a/charts/hush-sensor/templates/sentrydeployment.yaml
+++ b/charts/hush-sensor/templates/sentrydeployment.yaml
@@ -94,6 +94,8 @@ spec:
                   name: {{ .name }}
                   key: {{ .key }}
             {{- end }}
+            - name: DEPLOYMENT_KIND
+              value: k8s
             - name: SENTRY_SCAN_CONFIG_MAPS
               value: "1"
             - name: PLUTO_CRAWL_K8S_SECRETSTORE
@@ -122,6 +124,8 @@ spec:
                   name: {{ .name }}
                   key: {{ .key }}
             {{- end }}
+            - name: DEPLOYMENT_KIND
+              value: k8s
             {{- if .Values.eventReportingConsole }}
             - name: EVENT_REPORTING_CONSOLE
               valueFrom:

--- a/charts/hush-sensor/templates/vermonclusterrole.yaml
+++ b/charts/hush-sensor/templates/vermonclusterrole.yaml
@@ -14,4 +14,7 @@ rules:
   - apiGroups: ["apps"]
     resources: ["daemonsets", "deployments"]
     verbs: ["patch"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get"]
 {{- end -}}

--- a/charts/hush-sensor/templates/vermonclusterrole.yaml
+++ b/charts/hush-sensor/templates/vermonclusterrole.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.vermon.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: {{ include "hush-sensor.vermonFullName" . }}
   labels: {{- include "hush-sensor.labels" . | nindent 4 }}

--- a/charts/hush-sensor/templates/vermonclusterrolebinding.yaml
+++ b/charts/hush-sensor/templates/vermonclusterrolebinding.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.vermon.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: {{ include "hush-sensor.vermonFullName" . }}
   labels: {{- include "hush-sensor.labels" . | nindent 4 }}
@@ -9,7 +9,7 @@ subjects:
   name: {{ include "hush-sensor.vermonFullName" . }}
   namespace: {{ include "hush-sensor.namespace" . }}
 roleRef:
-  kind: Role
+  kind: ClusterRole
   name: {{ include "hush-sensor.vermonFullName" . }}
   apiGroup: rbac.authorization.k8s.io
 {{- end -}}

--- a/charts/hush-sensor/templates/vermondeployment.yaml
+++ b/charts/hush-sensor/templates/vermondeployment.yaml
@@ -102,6 +102,8 @@ spec:
             {{- end }}
             - name: DEPLOYMENT_KIND
               value: k8s
+            - name: CONTAINER_REGISTRY
+              value: {{ include "hush-sensor.imageRegistry" . | quote }}
         - name: hush-vermon-vector
           image: {{ include "hush-sensor.sensorVectorImagePath" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/charts/hush-sensor/templates/vermondeployment.yaml
+++ b/charts/hush-sensor/templates/vermondeployment.yaml
@@ -100,6 +100,8 @@ spec:
                   name: {{ .name }}
                   key: {{ .key }}
             {{- end }}
+            - name: DEPLOYMENT_KIND
+              value: k8s
         - name: hush-vermon-vector
           image: {{ include "hush-sensor.sensorVectorImagePath" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -124,6 +126,8 @@ spec:
                   name: {{ .name }}
                   key: {{ .key }}
             {{- end }}
+            - name: DEPLOYMENT_KIND
+              value: k8s
             {{- if .Values.eventReportingConsole }}
             - name: EVENT_REPORTING_CONSOLE
               valueFrom:

--- a/charts/hush-sensor/templates/vermondeployment.yaml
+++ b/charts/hush-sensor/templates/vermondeployment.yaml
@@ -84,30 +84,17 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            - name: LOG_CONFIG_ENDPOINT
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "hush-sensor.sensorConfigMapName" . }}
-                  key: log_config_uri
-            - name: CHANNEL_DIGESTS_ENDPOINT
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "hush-sensor.sensorConfigMapName" . }}
-                  key: channel_digests_uri
             - name: CHANNEL_DIGESTS_PERIOD
               value: {{ .Values.vermon.updateFrequency }}
-            - name: EVENT_REPORTING_ORG_ID
+            {{- with (include "hush-sensor.effectiveDeploymentTokenSecretRef" . | fromYaml) }}
+            - name: DEPLOYMENT_TOKEN
               valueFrom:
-                configMapKeyRef:
-                  name: {{ include "hush-sensor.sensorConfigMapName" . }}
-                  key: org_id
-            - name: EVENT_REPORTING_DEPLOYMENT_ID
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "hush-sensor.sensorConfigMapName" . }}
-                  key: deployment_id
+                secretKeyRef:
+                  name: {{ .name }}
+                  key: {{ .key }}
+            {{- end }}
             {{- with (include "hush-sensor.effectiveDeploymentPasswordSecretRef" . | fromYaml) }}
-            - name: EVENT_REPORTING_TOKEN
+            - name: DEPLOYMENT_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ .name }}
@@ -123,28 +110,15 @@ spec:
             - name: vector-socket
               mountPath: /tmp/vector
           env:
-            - name: EVENT_REPORTING_ENDPOINT
+            {{- with (include "hush-sensor.effectiveDeploymentTokenSecretRef" . | fromYaml) }}
+            - name: DEPLOYMENT_TOKEN
               valueFrom:
-                configMapKeyRef:
-                  name: {{ include "hush-sensor.sensorConfigMapName" . }}
-                  key: event_reporting_uri
-            - name: LOG_REPORTING_ENDPOINT
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "hush-sensor.sensorConfigMapName" . }}
-                  key: log_reporting_uri
-            - name: EVENT_REPORTING_ORG_ID
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "hush-sensor.sensorConfigMapName" . }}
-                  key: org_id
-            - name: EVENT_REPORTING_DEPLOYMENT_ID
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "hush-sensor.sensorConfigMapName" . }}
-                  key: deployment_id
+                secretKeyRef:
+                  name: {{ .name }}
+                  key: {{ .key }}
+            {{- end }}
             {{- with (include "hush-sensor.effectiveDeploymentPasswordSecretRef" . | fromYaml) }}
-            - name: EVENT_REPORTING_TOKEN
+            - name: DEPLOYMENT_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ .name }}
@@ -157,8 +131,6 @@ spec:
                   name: {{ include "hush-sensor.sensorConfigMapName" . }}
                   key: event_reporting_console
             {{- end }}
-            - name: KUBE_SYSTEM_UID
-              value: {{ include "hush-sensor.kubeSystemUid" . }}
             - name: HELM_RELEASE
               value: {{ .Release.Name }}
             - name: HELM_NAMESPACE

--- a/tests/common/process.py
+++ b/tests/common/process.py
@@ -9,7 +9,11 @@ def bash(cmd, env=None, **kwargs):
         logger.info("run: %s", cmd)
     try:
         return subprocess.check_output(
-            f"bash -ec 'set -o pipefail; {cmd}'", shell=True, text=True, env=env
+            f"bash -ec 'set -o pipefail; {cmd}'",
+            shell=True,
+            text=True,
+            env=env,
+            stderr=subprocess.PIPE,
         )
     except subprocess.CalledProcessError as e:
         logger.error(

--- a/tests/common/process.py
+++ b/tests/common/process.py
@@ -5,6 +5,7 @@ logger = logging.getLogger(__name__)
 
 
 def bash(cmd, env=None, **kwargs):
+    traceErr = kwargs.pop("traceErr", True)
     if kwargs.pop("trace", True):
         logger.info("run: %s", cmd)
     try:
@@ -16,7 +17,11 @@ def bash(cmd, env=None, **kwargs):
             stderr=subprocess.PIPE,
         )
     except subprocess.CalledProcessError as e:
-        logger.error(
-            "command failed: %s\nstdout=\n%s\nstderr=\n%s\n", cmd, e.stdout, e.stderr
-        )
+        if traceErr:
+            logger.error(
+                "command failed: %s\nstdout=\n%s\nstderr=\n%s\n",
+                cmd,
+                e.stdout,
+                e.stderr,
+            )
         raise e


### PR DESCRIPTION

`lookup` cannot be used in some environments (e.g. `argocd`).

Stop using `lookup`. Consequently, stop parsing deployment 
token in Helm. When user provides a reference to a pre-created 
Secret with deployment token/password we do not see the value.
Hence, as we do not use `lookup` anymore, we cannot parse it.

Generation of configuration items based on deployment token
atoms is responsibility of Pods now.