### PR TITLE
HUSH-2199 github: stop using `reviewers` attribute in dependabot configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @danaHush @moshe-hush @sladkani @r-bk

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,6 @@ updates:
       interval: daily
     commit-message:
       prefix: "HUSH-777 "
-    reviewers:
-      - "r-bk"
   - package-ecosystem: "pip"
     directories:
       - "/cli"
@@ -21,5 +19,3 @@ updates:
           - "*"
     commit-message:
       prefix: "HUSH-777 "
-    reviewers:
-      - "r-bk"


### PR DESCRIPTION
This attribute was deprecated [1] and is replaced by CODEOWNERS file.

Set codeowners to most frequent contributors to the repository.

[1] https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/
