### PR TITLE
HUSH-2108 hush-sensor: rename helpers to disambiguate the word "secret"

### DIFF
--- a/charts/hush-sensor/templates/connectordeployment.yaml
+++ b/charts/hush-sensor/templates/connectordeployment.yaml
@@ -35,7 +35,7 @@ spec:
       {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
-      {{- with (include "hush-sensor.imagePullSecretEffectiveList" .) }}
+      {{- with (include "hush-sensor.kubeImagePullSecretEffectiveList" .) }}
       imagePullSecrets: {{- . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.connector.terminationGracePeriodSeconds }}
@@ -51,14 +51,14 @@ spec:
           volumeMounts: {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
-            {{- with (include "hush-sensor.effectiveDeploymentTokenSecretRef" . | fromYaml) }}
+            {{- with (include "hush-sensor.effectiveDeploymentTokenKubeSecretRef" . | fromYaml) }}
             - name: DEPLOYMENT_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ .name }}
                   key: {{ .key }}
             {{- end }}
-            {{- with (include "hush-sensor.effectiveDeploymentPasswordSecretRef" . | fromYaml) }}
+            {{- with (include "hush-sensor.effectiveDeploymentPasswordKubeSecretRef" . | fromYaml) }}
             - name: DEPLOYMENT_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -81,14 +81,14 @@ spec:
           volumeMounts: {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
-            {{- with (include "hush-sensor.effectiveDeploymentTokenSecretRef" . | fromYaml) }}
+            {{- with (include "hush-sensor.effectiveDeploymentTokenKubeSecretRef" . | fromYaml) }}
             - name: DEPLOYMENT_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ .name }}
                   key: {{ .key }}
             {{- end }}
-            {{- with (include "hush-sensor.effectiveDeploymentPasswordSecretRef" . | fromYaml) }}
+            {{- with (include "hush-sensor.effectiveDeploymentPasswordKubeSecretRef" . | fromYaml) }}
             - name: DEPLOYMENT_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/hush-sensor/templates/daemonset.yaml
+++ b/charts/hush-sensor/templates/daemonset.yaml
@@ -37,7 +37,7 @@ spec:
       hostPID: true
       dnsPolicy: ClusterFirstWithHostNet
       restartPolicy: Always
-      {{- with (include "hush-sensor.imagePullSecretEffectiveList" .) }}
+      {{- with (include "hush-sensor.kubeImagePullSecretEffectiveList" .) }}
       imagePullSecrets: {{- . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.daemonSet.terminationGracePeriodSeconds }}
@@ -104,14 +104,14 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            {{- with (include "hush-sensor.effectiveDeploymentTokenSecretRef" . | fromYaml) }}
+            {{- with (include "hush-sensor.effectiveDeploymentTokenKubeSecretRef" . | fromYaml) }}
             - name: DEPLOYMENT_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ .name }}
                   key: {{ .key }}
             {{- end }}
-            {{- with (include "hush-sensor.effectiveDeploymentPasswordSecretRef" . | fromYaml) }}
+            {{- with (include "hush-sensor.effectiveDeploymentPasswordKubeSecretRef" . | fromYaml) }}
             - name: DEPLOYMENT_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -130,14 +130,14 @@ spec:
             - name: vector-socket
               mountPath: /tmp/vector
           env:
-            {{- with (include "hush-sensor.effectiveDeploymentTokenSecretRef" . | fromYaml) }}
+            {{- with (include "hush-sensor.effectiveDeploymentTokenKubeSecretRef" . | fromYaml) }}
             - name: DEPLOYMENT_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ .name }}
                   key: {{ .key }}
             {{- end }}
-            {{- with (include "hush-sensor.effectiveDeploymentPasswordSecretRef" . | fromYaml) }}
+            {{- with (include "hush-sensor.effectiveDeploymentPasswordKubeSecretRef" . | fromYaml) }}
             - name: DEPLOYMENT_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/hush-sensor/templates/deploymentsecret.yaml
+++ b/charts/hush-sensor/templates/deploymentsecret.yaml
@@ -1,16 +1,16 @@
-{{- if (include "hush-sensor.shouldCreateDeploymentSecret" .) -}}
+{{- if (include "hush-sensor.shouldCreateDeploymentKubeSecret" .) -}}
 apiVersion: v1
 kind: Secret
 type: Opaque
 metadata:
-  name: {{ include "hush-sensor.deploymentSecretName" . }}
+  name: {{ include "hush-sensor.deploymentKubeSecretName" . }}
   labels: {{- include "hush-sensor.labels" . | nindent 4 }}
   namespace: {{ include "hush-sensor.namespace" . }}
 data:
-  {{- if (include "hush-sensor.shouldCreateDeploymentTokenSecret" .) }}
+  {{- if (include "hush-sensor.shouldCreateDeploymentTokenKubeSecret" .) }}
   deployment-token: {{ (include "hush-sensor.getDeploymentTokenValue" .) | b64enc }}
   {{- end }}
-  {{- if (include "hush-sensor.shouldCreateDeploymentPasswordSecret" .) }}
+  {{- if (include "hush-sensor.shouldCreateDeploymentPasswordKubeSecret" .) }}
   deployment-password: {{ (include "hush-sensor.getDeploymentPasswordValue" .) | b64enc }}
   {{- end }}
 {{- end }}

--- a/charts/hush-sensor/templates/imagepullsecret.yaml
+++ b/charts/hush-sensor/templates/imagepullsecret.yaml
@@ -1,11 +1,11 @@
-{{- if (include "hush-sensor.shouldCreateImagePullSecret" .) -}}
+{{- if (include "hush-sensor.shouldCreateKubeImagePullSecret" .) -}}
 apiVersion: v1
 kind: Secret
 type: kubernetes.io/dockerconfigjson
 metadata:
-  name: {{ include "hush-sensor.imagePullSecretName" . }}
+  name: {{ include "hush-sensor.kubeImagePullSecretName" . }}
   labels: {{- include "hush-sensor.labels" . | nindent 4 }}
   namespace: {{ include "hush-sensor.namespace" . }}
 data:
-  .dockerconfigjson: {{ include "hush-sensor.imagePullSecretValue" . | quote }}
+  .dockerconfigjson: {{ include "hush-sensor.kubeImagePullSecretData" . | quote }}
 {{- end -}}

--- a/charts/hush-sensor/templates/sentrydeployment.yaml
+++ b/charts/hush-sensor/templates/sentrydeployment.yaml
@@ -35,7 +35,7 @@ spec:
       {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
-      {{- with (include "hush-sensor.imagePullSecretEffectiveList" .) }}
+      {{- with (include "hush-sensor.kubeImagePullSecretEffectiveList" .) }}
       imagePullSecrets: {{- . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.sentry.terminationGracePeriodSeconds }}
@@ -80,14 +80,14 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            {{- with (include "hush-sensor.effectiveDeploymentTokenSecretRef" . | fromYaml) }}
+            {{- with (include "hush-sensor.effectiveDeploymentTokenKubeSecretRef" . | fromYaml) }}
             - name: DEPLOYMENT_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ .name }}
                   key: {{ .key }}
             {{- end }}
-            {{- with (include "hush-sensor.effectiveDeploymentPasswordSecretRef" . | fromYaml) }}
+            {{- with (include "hush-sensor.effectiveDeploymentPasswordKubeSecretRef" . | fromYaml) }}
             - name: DEPLOYMENT_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -110,14 +110,14 @@ spec:
             - name: vector-socket
               mountPath: /tmp/vector
           env:
-            {{- with (include "hush-sensor.effectiveDeploymentTokenSecretRef" . | fromYaml) }}
+            {{- with (include "hush-sensor.effectiveDeploymentTokenKubeSecretRef" . | fromYaml) }}
             - name: DEPLOYMENT_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ .name }}
                   key: {{ .key }}
             {{- end }}
-            {{- with (include "hush-sensor.effectiveDeploymentPasswordSecretRef" . | fromYaml) }}
+            {{- with (include "hush-sensor.effectiveDeploymentPasswordKubeSecretRef" . | fromYaml) }}
             - name: DEPLOYMENT_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/hush-sensor/templates/vermondeployment.yaml
+++ b/charts/hush-sensor/templates/vermondeployment.yaml
@@ -35,7 +35,7 @@ spec:
       {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
-      {{- with (include "hush-sensor.imagePullSecretEffectiveList" .) }}
+      {{- with (include "hush-sensor.kubeImagePullSecretEffectiveList" .) }}
       imagePullSecrets: {{- . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.vermon.terminationGracePeriodSeconds }}
@@ -86,14 +86,14 @@ spec:
                   fieldPath: metadata.name
             - name: CHANNEL_DIGESTS_PERIOD
               value: {{ .Values.vermon.updateFrequency }}
-            {{- with (include "hush-sensor.effectiveDeploymentTokenSecretRef" . | fromYaml) }}
+            {{- with (include "hush-sensor.effectiveDeploymentTokenKubeSecretRef" . | fromYaml) }}
             - name: DEPLOYMENT_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ .name }}
                   key: {{ .key }}
             {{- end }}
-            {{- with (include "hush-sensor.effectiveDeploymentPasswordSecretRef" . | fromYaml) }}
+            {{- with (include "hush-sensor.effectiveDeploymentPasswordKubeSecretRef" . | fromYaml) }}
             - name: DEPLOYMENT_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -114,14 +114,14 @@ spec:
             - name: vector-socket
               mountPath: /tmp/vector
           env:
-            {{- with (include "hush-sensor.effectiveDeploymentTokenSecretRef" . | fromYaml) }}
+            {{- with (include "hush-sensor.effectiveDeploymentTokenKubeSecretRef" . | fromYaml) }}
             - name: DEPLOYMENT_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ .name }}
                   key: {{ .key }}
             {{- end }}
-            {{- with (include "hush-sensor.effectiveDeploymentPasswordSecretRef" . | fromYaml) }}
+            {{- with (include "hush-sensor.effectiveDeploymentPasswordKubeSecretRef" . | fromYaml) }}
             - name: DEPLOYMENT_PASSWORD
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
The chart uses the word "secret" for several purposes:

- K8S Secret created to store Hush deployment credentials
- K8S Secret created to store Hush image-pull secret
- Hush Image-Pull secret itself

Prefix helpers that denote K8S Secret with the word "kube" to remove
ambiguity.
