### PR TITLE
HUSH-2197 hush-sensor: daemontset: Do not run the daemonset pod in host network

### DIFF
--- a/charts/hush-sensor/templates/daemonset.yaml
+++ b/charts/hush-sensor/templates/daemonset.yaml
@@ -33,7 +33,6 @@ spec:
       {{- with .Values.daemonSet.affinity }}
       affinity: {{- toYaml . | nindent 8 }}
       {{- end }}
-      hostNetwork: true
       hostPID: true
       dnsPolicy: ClusterFirstWithHostNet
       restartPolicy: Always


### PR DESCRIPTION

Was once needed for snoopy to run within the host UTS namespace.
No longer needed since snoopy v0.25, where snoopy forces itself into the
host UTS namespace (using nsenter -u).

So there is no good reason to run the daemonset pod in host network;
moreover, going forward, snoopy will expose a local prometheus endpoint,
it is wrong to bind in the host network namespace.
