### PR TITLE
HUSH-3001 hush-sensor: remove catch-all toleration from Deployments

### DIFF
--- a/charts/hush-sensor/values.yaml
+++ b/charts/hush-sensor/values.yaml
@@ -282,11 +282,9 @@ sentry:
                 - arm64
 
   # A list of tolerations.
-  # Match all taints by default.
   # For more information see
   # https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-  tolerations:
-    - operator: "Exists"
+  tolerations: []
 
   # An additional set of volumes
   extraVolumes: []
@@ -380,11 +378,9 @@ vermon:
                 - arm64
 
   # A list of tolerations.
-  # Match all taints by default.
   # For more information see
   # https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-  tolerations:
-    - operator: "Exists"
+  tolerations: []
 
   # An additional set of volumes
   extraVolumes: []
@@ -453,11 +449,9 @@ connector:
                 - arm64
 
   # A list of tolerations.
-  # Match all taints by default.
   # For more information see
   # https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-  tolerations:
-    - operator: "Exists"
+  tolerations: []
 
   # An additional set of mounts for connector-client
   clientExtraVolumeMounts: []


### PR DESCRIPTION
Leave it on the DaemonSet only.

The reason for this change is that the catch-all toleration allows pods
to run on all nodes including cordoned ones. Running single-instance
Deployments on cordoned nodes is less preferable.

Initially catch-all toleration was added to all deployments to allow
them run on node pools managed/maintained with taints. However, even in
those cases it is assumed that some nodes are untainted. For the
edge case when all nodes are tainted a User has the ability to customize
the tolerations to her needs.