### PR TITLE
HUSH-5063 hush-sensor: add sentry Azure Key Vault integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## hush-sensor [unreleased]
+
+### Added
+
+- add support for `azure` integration configuration in `sentry`.
+
 ## hush-sensor 0.26.0 - 2026-04-05
 
 ### Added

--- a/charts/hush-sensor/ci/sentry-integrations-azure-kv-sp-mgmt-group-values.yaml
+++ b/charts/hush-sensor/ci/sentry-integrations-azure-kv-sp-mgmt-group-values.yaml
@@ -1,0 +1,17 @@
+---
+hushDeployment:
+  token: "ZDE6em9uZTpyZWFsbTpvcmctaWQ6ZGVwbG95bWVudC1pZA=="
+  password: "koko.password"
+
+sentry:
+  integrations:
+    azure:
+      tenant_id: "11111111-2222-3333-4444-555555555555"
+      management_group_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+      auth:
+        service_principal:
+          client_id: "66666666-7777-8888-9999-000000000000"
+          clientSecret:
+            secretKeyRef:
+              name: "azure-sp-secret"
+              key: "client-secret"

--- a/charts/hush-sensor/ci/sentry-integrations-azure-kv-sp-values.yaml
+++ b/charts/hush-sensor/ci/sentry-integrations-azure-kv-sp-values.yaml
@@ -1,0 +1,18 @@
+---
+hushDeployment:
+  token: "ZDE6em9uZTpyZWFsbTpvcmctaWQ6ZGVwbG95bWVudC1pZA=="
+  password: "koko.password"
+
+sentry:
+  integrations:
+    azure:
+      tenant_id: "11111111-2222-3333-4444-555555555555"
+      subscription_ids:
+        - "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+      auth:
+        service_principal:
+          client_id: "66666666-7777-8888-9999-000000000000"
+          clientSecret:
+            secretKeyRef:
+              name: "azure-sp-secret"
+              key: "client-secret"

--- a/charts/hush-sensor/ci/sentry-integrations-azure-kv-wi-values.yaml
+++ b/charts/hush-sensor/ci/sentry-integrations-azure-kv-wi-values.yaml
@@ -1,0 +1,12 @@
+---
+hushDeployment:
+  token: "ZDE6em9uZTpyZWFsbTpvcmctaWQ6ZGVwbG95bWVudC1pZA=="
+  password: "koko.password"
+
+sentry:
+  integrations:
+    azure:
+      tenant_id: "11111111-2222-3333-4444-555555555555"
+      auth:
+        workload_identity:
+          client_id: "66666666-7777-8888-9999-000000000000"

--- a/charts/hush-sensor/templates/_helpers.tpl
+++ b/charts/hush-sensor/templates/_helpers.tpl
@@ -305,6 +305,100 @@ Sentry deployment projected volume for hc vault integration with JWT Auth
 
 
 {{/*
+Check if Sentry Azure KV integration is enabled.
+Enabled when tenant_id is set. Auth method is validated separately.
+*/}}
+{{- define "hush-sensor.sentryAzureKvEnabled" -}}
+{{- if dig "integrations" "azure" "tenant_id" "" .Values.sentry -}}
+true
+{{- end -}}
+{{- end }}
+
+{{/*
+Check if Sentry Azure KV Service Principal auth is enabled.
+True when all SP fields are populated: client_id + clientSecret.secretKeyRef.{name,key}.
+*/}}
+{{- define "hush-sensor.sentryAzureKvSPEnabled" -}}
+{{- $akv := .Values.sentry.integrations.azure -}}
+{{- $clientId := dig "auth" "service_principal" "client_id" "" $akv -}}
+{{- $secretName := dig "auth" "service_principal" "clientSecret" "secretKeyRef" "name" "" $akv -}}
+{{- $secretKey := dig "auth" "service_principal" "clientSecret" "secretKeyRef" "key" "" $akv -}}
+{{- if and (include "hush-sensor.sentryAzureKvEnabled" .) $clientId $secretName $secretKey -}}
+true
+{{- end -}}
+{{- end }}
+
+{{/*
+Sentry Azure KV Client Secret secret ref
+*/}}
+{{- define "hush-sensor.sentryAzureKvClientSecretSecretRef" -}}
+{{- if (include "hush-sensor.sentryAzureKvSPEnabled" .) -}}
+    {{- dict
+        "name" .Values.sentry.integrations.azure.auth.service_principal.clientSecret.secretKeyRef.name
+        "key" .Values.sentry.integrations.azure.auth.service_principal.clientSecret.secretKeyRef.key
+        | toYaml
+    -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Validate that only one Azure KV auth method is configured.
+Fails if both service_principal and workload_identity are configured simultaneously.
+*/}}
+{{- define "hush-sensor.validateAzureKvAuthMethod" -}}
+{{- if not .Values.sentry.integrations.azure.tenant_id -}}
+    {{- fail "sentry.integrations.azure: tenant_id is required" -}}
+{{- end -}}
+{{- $akv := .Values.sentry.integrations.azure -}}
+{{- $hasSP := (include "hush-sensor.sentryAzureKvSPEnabled" .) -}}
+{{- $hasWI := dig "auth" "workload_identity" "client_id" "" $akv -}}
+{{- $spClientId := dig "auth" "service_principal" "client_id" "" $akv -}}
+{{- if and $spClientId (not $hasSP) -}}
+    {{- fail "sentry.integrations.azure.auth.service_principal: client_id is set but clientSecret.secretKeyRef.name and key are also required" -}}
+{{- end -}}
+{{- if and (not $hasSP) (not $hasWI) -}}
+    {{- fail "sentry.integrations.azure: at least one auth method (service_principal or workload_identity) must be configured" -}}
+{{- end -}}
+{{- if and $hasSP $hasWI -}}
+    {{- fail "sentry.integrations.azure: only one auth method (service_principal or workload_identity) can be configured at a time" -}}
+{{- end -}}
+{{- if and $akv.management_group_id $akv.subscription_ids (kindIs "slice" $akv.subscription_ids) (gt (len $akv.subscription_ids) 0) -}}
+    {{- fail "sentry.integrations.azure: management_group_id and subscription_ids are mutually exclusive" -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Sentry Azure KV integration configuration.
+Produces the azure: block matching the Go config struct.
+When using Workload Identity (no SP), the auth block is omitted — Go falls back to defaultAuth.
+*/}}
+{{- define "hush-sensor.sentryAzureKvIntegration" -}}
+{{- if (include "hush-sensor.sentryAzureKvEnabled" .) -}}
+  {{- include "hush-sensor.validateAzureKvAuthMethod" . -}}
+  {{- $akv := .Values.sentry.integrations.azure -}}
+  {{- $hasSP := (include "hush-sensor.sentryAzureKvSPEnabled" .) -}}
+azure:
+  enabled: true
+  tenant_id: {{ $akv.tenant_id | quote }}
+  {{- if $akv.management_group_id }}
+  management_group_id: {{ $akv.management_group_id | quote }}
+  {{- end }}
+  {{- if and $akv.subscription_ids (kindIs "slice" $akv.subscription_ids) (gt (len $akv.subscription_ids) 0) }}
+  subscription_ids:
+    {{- range $akv.subscription_ids }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  {{- if $hasSP }}
+  auth:
+    service_principal:
+      client_id: {{ $akv.auth.service_principal.client_id | quote }}
+      client_secret_env: "AZURE_CLIENT_SECRET"
+  {{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Kubernetes version
 */}}
 {{- define "hush-sensor.kubeVersion" -}}
@@ -701,6 +795,28 @@ Sentry service account annotations with AWS IAM role handling
     {{- end -}}
   {{- else -}}
     {{- $_ := set $annotations $roleArnKey .Values.sentry.integrations.aws.irsa -}}
+  {{- end -}}
+{{- end -}}
+{{- $wiClientIdKey := "azure.workload.identity/client-id" -}}
+{{- if dig "integrations" "azure" "auth" "workload_identity" "client_id" "" .Values.sentry -}}
+  {{- if hasKey $annotations $wiClientIdKey -}}
+    {{- $existingId := get $annotations $wiClientIdKey -}}
+    {{- if ne $existingId .Values.sentry.integrations.azure.auth.workload_identity.client_id -}}
+      {{- fail (printf "Error: inconsistent sentry service account annotation for %s. Expected %s" $wiClientIdKey .Values.sentry.integrations.azure.auth.workload_identity.client_id) -}}
+    {{- end -}}
+  {{- else -}}
+    {{- $_ := set $annotations $wiClientIdKey .Values.sentry.integrations.azure.auth.workload_identity.client_id -}}
+  {{- end -}}
+{{- end -}}
+{{- $wiTenantIdKey := "azure.workload.identity/tenant-id" -}}
+{{- if and (dig "integrations" "azure" "auth" "workload_identity" "client_id" "" .Values.sentry) (dig "integrations" "azure" "tenant_id" "" .Values.sentry) -}}
+  {{- if hasKey $annotations $wiTenantIdKey -}}
+    {{- $existingId := get $annotations $wiTenantIdKey -}}
+    {{- if ne $existingId .Values.sentry.integrations.azure.tenant_id -}}
+      {{- fail (printf "Error: inconsistent sentry service account annotation for %s. Expected %s" $wiTenantIdKey .Values.sentry.integrations.azure.tenant_id) -}}
+    {{- end -}}
+  {{- else -}}
+    {{- $_ := set $annotations $wiTenantIdKey .Values.sentry.integrations.azure.tenant_id -}}
   {{- end -}}
 {{- end -}}
 {{- if $annotations -}}

--- a/charts/hush-sensor/templates/sensorconfigmap.yaml
+++ b/charts/hush-sensor/templates/sensorconfigmap.yaml
@@ -32,3 +32,6 @@ data:
     {{- with (include "hush-sensor.sentryHcVaultIntegration" .) }}
     {{- . | nindent 6 -}}
     {{- end }}
+    {{- with (include "hush-sensor.sentryAzureKvIntegration" .) }}
+    {{- . | nindent 6 -}}
+    {{- end }}

--- a/charts/hush-sensor/templates/sentrydeployment.yaml
+++ b/charts/hush-sensor/templates/sentrydeployment.yaml
@@ -17,6 +17,9 @@ spec:
     metadata:
       labels: {{- include "hush-sensor.labels" . | nindent 8 }}
         app.kubernetes.io/component: sentry
+      {{- if dig "integrations" "azure" "auth" "workload_identity" "client_id" "" .Values.sentry }}
+        azure.workload.identity/use: "true"
+      {{- end }}
       {{ with .Values.sentry.annotations -}}
       annotations: {{- . | nindent 8 }}
       {{- end }}
@@ -127,6 +130,13 @@ spec:
               value: "1"
             {{- with (include "hush-sensor.sentryHcVaultTokenSecretRef" . | fromYaml) }}
             - name: SENTRY_VAULT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .name }}
+                  key: {{ .key }}
+            {{- end }}
+            {{- with (include "hush-sensor.sentryAzureKvClientSecretSecretRef" . | fromYaml) }}
+            - name: AZURE_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ .name }}

--- a/charts/hush-sensor/values.yaml
+++ b/charts/hush-sensor/values.yaml
@@ -364,6 +364,49 @@ sentry:
           # vault role with token_policies required by crawler
           role: ""
 
+    azure:
+      # Azure tenant ID. Required
+      tenant_id: ""
+
+      # Management Group ID.
+      # Optional. If set, only subscriptions under management_group_id will
+      # be scanned.
+      management_group_id: ""
+
+      # List of Azure subscription IDs to crawl.
+      # If set, only listed subscriptions will be scanned.
+      # If empty, subscriptions are auto-discovered with management_group_id
+      # or tenant_id.
+      # Only one of management_group_id and subscription_ids can be set.
+      # subscription_ids:
+      #   - "<subscription-id>"
+      subscription_ids: []
+
+      auth:
+        # Service principal authentication.
+        # Requires tenant_id to be set above.
+        service_principal:
+
+          # Azure AD application (client) ID
+          client_id: ""
+
+          # Reference to a pre-created K8s Secret containing the client secret.
+          # The secret value will be injected as env var AZURE_CLIENT_SECRET.
+          clientSecret:
+            secretKeyRef:
+              # Secret name
+              name: ""
+
+              # Key within the secret
+              key: ""
+
+        # Azure Workload Identity client ID for default credential auth.
+        # When set, the sentry service account is annotated with
+        # azure.workload.identity/client-id and the pod is labeled accordingly.
+        # Do NOT set both this and service_principal auth.
+        workload_identity:
+          client_id: ""
+
 vermon:
   # Hush Security Vermon keeps hush sensor channel images up to date.
   # Hush Sensor containers must be deployed with image pull policy "Always"


### PR DESCRIPTION
Support service principal auth (client secret injected from K8s Secret ref) and workload identity auth (Azure AD federated credentials via SA/pod annotations). Auth methods are mutually exclusive.
Also validates management_group_id vs subscription_ids.