### PR TITLE
HUSH-5437 Support OIDC authentication

### DIFF
--- a/charts/hush-am/ci/auth-mode-oidc-values.yaml
+++ b/charts/hush-am/ci/auth-mode-oidc-values.yaml
@@ -1,0 +1,9 @@
+---
+hushDeployment:
+  authMode: "oidc"
+  token: "ZDE6em9uZTpyZWFsbTpvcmctaWQ6ZGVwbG95bWVudC1pZA=="
+
+secretStore:
+  kind: "awssm"
+  aws:
+    region: "eu-central-1"

--- a/charts/hush-am/ci/auth-mode-password-values.yaml
+++ b/charts/hush-am/ci/auth-mode-password-values.yaml
@@ -1,0 +1,10 @@
+---
+hushDeployment:
+  authMode: "password"
+  token: "ZDE6em9uZTpyZWFsbTpvcmctaWQ6ZGVwbG95bWVudC1pZA=="
+  password: "koko.password"
+
+secretStore:
+  kind: "awssm"
+  aws:
+    region: "eu-central-1"

--- a/charts/hush-am/templates/_helpers.yaml
+++ b/charts/hush-am/templates/_helpers.yaml
@@ -612,24 +612,26 @@ Which secret to use for deployment token?
 Which secret to use for deployment password?
 */}}
 {{- define "hush-am.effectiveDeploymentPasswordKubeSecretRef" -}}
-{{- if .Values.hushDeployment.password -}}
+{{- if include "hush-common.isPasswordAuthMode" . -}}
+  {{- if .Values.hushDeployment.password -}}
     {{- dict
         "name" (include "hush-common.deploymentKubeSecretName" .)
         "key" "deployment-password"
         | toYaml
     -}}
-{{- else if and .Values.hushDeployment.secretKeyRef.name .Values.hushDeployment.secretKeyRef.key -}}
+  {{- else if and .Values.hushDeployment.secretKeyRef.name .Values.hushDeployment.secretKeyRef.key -}}
     {{- dict
         "name" .Values.hushDeployment.secretKeyRef.name
         "key" .Values.hushDeployment.secretKeyRef.key
         | toYaml
     -}}
-{{- else -}}
+  {{- else -}}
     {{- dict
         "name" .Values.hushDeployment.sensorDeploymentSecretName
         "key" "deployment-password"
         | toYaml
     -}}
+  {{- end }}
 {{- end }}
 {{- end }}
 

--- a/charts/hush-am/templates/_helpers.yaml
+++ b/charts/hush-am/templates/_helpers.yaml
@@ -646,6 +646,8 @@ Mandatory envs
 {{- end }}
 - name: DEPLOYMENT_KIND
   value: k8s
+- name: HUSH_AUTH_MODE
+  value: {{ .Values.hushDeployment.authMode | quote }}
 - name: MUFASA_K8S_NAMESPACE
   valueFrom:
     fieldRef:

--- a/charts/hush-am/values.yaml
+++ b/charts/hush-am/values.yaml
@@ -31,6 +31,7 @@ hushDeployment:
   # Authentication mode for Hush API token exchange.
   # Allowed values:
   # - password - use deployment password (default)
+  # - oidc - use K8S SA token (oidc_provider must be configured in deployment)
   authMode: "password"
 
   # The deployment token as received from API/UI.

--- a/charts/hush-am/values.yaml
+++ b/charts/hush-am/values.yaml
@@ -28,6 +28,11 @@ clusterDomain: cluster.local
 
 # Hush deployment configuration
 hushDeployment:
+  # Authentication mode for Hush API token exchange.
+  # Allowed values:
+  # - password - use deployment password (default)
+  authMode: "password"
+
   # The deployment token as received from API/UI.
   token: ""
 

--- a/charts/hush-common/templates/_helpers.yaml
+++ b/charts/hush-common/templates/_helpers.yaml
@@ -234,3 +234,27 @@ K8S SA token path
 {{- define "hush-common.k8sSaTokenPath" -}}
 {{ include "hush-common.k8sSecretsProjectionVolumePath" . }}/{{ include "hush-common.k8sSaTokenFileName" . }}
 {{- end }}
+
+{{/*
+Validate auth mode value.
+*/}}
+{{- define "hush-common.validateAuthMode" -}}
+{{- $mode := .Values.hushDeployment.authMode -}}
+{{- if $mode -}}
+  {{- $validModes := list "password" "oidc" -}}
+  {{- if not (has $mode $validModes) -}}
+    {{- fail (printf "'hushDeployment.authMode' must be one of %v, got %q" $validModes $mode) -}}
+  {{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Is the auth mode set to password (or unset, for backward compatibility)?
+*/}}
+{{- define "hush-common.isPasswordAuthMode" -}}
+{{- include "hush-common.validateAuthMode" . -}}
+{{- $mode := .Values.hushDeployment.authMode -}}
+{{- if or (not $mode) (eq $mode "password") -}}
+true
+{{- end -}}
+{{- end }}


### PR DESCRIPTION

To allow users authenticate to Hush API with short-lived tokens signed
by K8S instead of deployment password.