### PR TITLE
HUSH-6004 hush-am: add support for custom KMS key in AWS secret store kinds

### DIFF
--- a/charts/hush-am/ci/awssm-silo-kms-values.yaml
+++ b/charts/hush-am/ci/awssm-silo-kms-values.yaml
@@ -1,0 +1,10 @@
+---
+hushDeployment:
+  token: "ZDE6em9uZTpyZWFsbTpvcmctaWQ6ZGVwbG95bWVudC1pZA=="
+  password: "koko.password"
+
+secretStore:
+  kind: "awssm"
+  aws:
+    region: "eu-central-1"
+    kmsKeyId: "arn:aws:kms:eu-central-1:000000000000:key/1234abcd-12ab-34cd-56ef-1234567890ab"

--- a/charts/hush-am/ci/awsssm-silo-kms-values.yaml
+++ b/charts/hush-am/ci/awsssm-silo-kms-values.yaml
@@ -1,0 +1,10 @@
+---
+hushDeployment:
+  token: "ZDE6em9uZTpyZWFsbTpvcmctaWQ6ZGVwbG95bWVudC1pZA=="
+  password: "koko.password"
+
+secretStore:
+  kind: "awsssm"
+  aws:
+    region: "eu-central-1"
+    kmsKeyId: "arn:aws:kms:eu-central-1:000000000000:alias/access-manager"

--- a/charts/hush-am/templates/_helpers.yaml
+++ b/charts/hush-am/templates/_helpers.yaml
@@ -488,6 +488,10 @@ Silo env vars
   value: {{ include "hush-am.siloNamespacePrefix" . | quote }}
 - name: SILO_AWS_SM_REGION
   value: {{ include "hush-am.siloAwsRegion" . | quote }}
+    {{- with (dig "aws" "kmsKeyId" "" .Values.secretStore) }}
+- name: SILO_AWS_SM_KMS_KEY_ID
+  value: {{ . | quote }}
+    {{- end }}
     {{- with (include "hush-am.siloAwsAccessToken" . | fromYaml) }}
 - name: AWS_SECRET_ACCESS_KEY
   value: {{ .secret_access_key | quote }}
@@ -505,6 +509,10 @@ Silo env vars
   value: {{ include "hush-am.siloNamespacePrefix" . | quote }}
 - name: SILO_AWS_SSM_REGION
   value: {{ include "hush-am.siloAwsRegion" . | quote }}
+    {{- with (dig "aws" "kmsKeyId" "" .Values.secretStore) }}
+- name: SILO_AWS_SSM_KMS_KEY_ID
+  value: {{ . | quote }}
+    {{- end }}
     {{- with (include "hush-am.siloAwsAccessToken" . | fromYaml) }}
 - name: AWS_SECRET_ACCESS_KEY
   value: {{ .secret_access_key | quote }}

--- a/charts/hush-am/values.yaml
+++ b/charts/hush-am/values.yaml
@@ -187,6 +187,45 @@ secretStore:
     # AWS region name, e.g. "us-east-1"
     region: ""
 
+    # Optional customer-managed KMS key used to encrypt the secret values.
+    #
+    # Accepts a KMS key ID, key ARN, alias name, or alias ARN. When empty,
+    # AWS uses the default account-managed key: aws/secretsmanager for
+    # 'awssm', aws/ssm for 'awsssm'.
+    #
+    # Behaviour and required KMS permissions depend on 'secretStore.kind'.
+    # In both cases the permissions must be granted to the principal used
+    # by the secret store (e.g. the IRSA role configured under
+    # 'accessManager.workloadIdentity.aws.irsa').
+    #
+    # awssm (AWS Secrets Manager):
+    #   - The KMS key is applied on CreateSecret only. Existing secrets
+    #     keep the KMS key they were created with.
+    #   - Secrets Manager uses envelope encryption: it asks KMS for a data
+    #     key under this CMK on CreateSecret / PutSecretValue, and calls
+    #     Decrypt on GetSecretValue to unwrap that data key.
+    #   - Required KMS actions on the key:
+    #       kms:GenerateDataKey  -- CreateSecret / PutSecretValue
+    #       kms:Decrypt          -- GetSecretValue (unwrap the data key)
+    #
+    # awsssm (AWS SSM Parameter Store):
+    #   - The KMS key is applied on every PutParameter, including
+    #     overwrites of existing parameters.
+    #   - Parameter Store uses different KMS operations depending on the
+    #     parameter tier: kms:Encrypt for standard SecureString parameters
+    #     (up to 4 KB) and kms:GenerateDataKey for advanced SecureString
+    #     parameters (up to 8 KB, via envelope encryption with the AWS
+    #     Encryption SDK). The secret store uses Intelligent-Tiering, so an
+    #     individual parameter can land in either tier and the role must
+    #     allow both.
+    #   - Required KMS actions on the key:
+    #       kms:Encrypt          -- PutParameter for standard SecureString
+    #       kms:GenerateDataKey  -- PutParameter for advanced SecureString
+    #       kms:Decrypt          -- GetParameter / GetParameters /
+    #                               GetParametersByPath with
+    #                               WithDecryption=true
+    kmsKeyId: ""
+
   # GCP secret store configuration
   gcp:
     # GCP project ID


### PR DESCRIPTION
To allow encryption of secrets with custom KMS instead of the default
one managed by AWS.
