### PR TITLE
HUSH-5436 Bump `hush-sensor` version

### DIFF
--- a/charts/hush-sensor/CHANGELOG.md
+++ b/charts/hush-sensor/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## hush-sensor [unreleased]
+## hush-sensor 0.29.0 - 2026-06-04
 
 ### Added
 

--- a/charts/hush-sensor/CHANGELOG.md
+++ b/charts/hush-sensor/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - authenticate to Hush API using short-lived access tokens
-- add `hushDeployment.authMode` value to choose the way access-token is onbtained:
+- add `hushDeployment.authMode` value to choose the way access-token is obtained:
   - `password` (default) - use `DEPLOYMENT_PASSWORD` to obtain an access-token
   - `oidc` - use OIDC JWT to obtain an access-token (requires OIDC configuration in
     deployment)

--- a/charts/hush-sensor/Chart.yaml
+++ b/charts/hush-sensor/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hush-sensor
 description: A Helm chart for Hush Security sensor.
 type: application
-version: 0.28.0
+version: 0.29.0
 home: https://hush.security
 dependencies:
   - name: hush-common


### PR DESCRIPTION
- **HUSH-5436 hush-sensor: fix a changelog typo**
- **HUSH-5436 hush-sensor: bump the version to 0.29.0**
