### PR TITLE
HUSH-5852 Allow `api-controller` get namespaces

### DIFF
--- a/charts/hush-am/CHANGELOG.md
+++ b/charts/hush-am/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Changed
+
+- add `namespaces:get` permission to api-controller's ClusterRole to allow it
+  query `kube-system` namespace UID as cluster identifier
+
 ## hush-am 0.17.0 - 2026-05-25
 
 ### Added

--- a/charts/hush-am/templates/apicontrollerrole.yaml
+++ b/charts/hush-am/templates/apicontrollerrole.yaml
@@ -40,4 +40,8 @@ rules:
   resources:
     - customresourcedefinitions
   verbs: ["get"]
+- apiGroups: [""]
+  resources:
+    - namespaces
+  verbs: ["get"]
 {{- end }}


### PR DESCRIPTION
- **HUSH-5436 hush-am: allow apicontroller get namespaces**
- **HUSH-5436 hush-am: add cluster role update to changelog**
