### PR TITLE
HUSH-5448 hush-am: stop restarting spire-agent on upgrade

### DIFF
--- a/charts/hush-am/CHANGELOG.md
+++ b/charts/hush-am/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- bump the default spire-agent image to `v0.14.0`. The first upgrade after this
+  restarts spire-agent pods once to roll out the new image.
 - spire-agent pods no longer restart on every chart upgrade, but only when
   their actual configuration changes. As part of this, spire-agent pods no
   longer carry the `helm.sh/chart` and `app.kubernetes.io/version` labels

--- a/charts/hush-am/CHANGELOG.md
+++ b/charts/hush-am/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Changed
+
+- spire-agent pods no longer restart on every chart upgrade, but only when
+  their actual configuration changes. As part of this, spire-agent pods no
+  longer carry the `helm.sh/chart` and `app.kubernetes.io/version` labels
+  (the spire-agent DaemonSet object still does).
+
 ## hush-am 0.18.1 - 2026-06-12
 
 ### Changed

--- a/charts/hush-am/templates/_helpers.yaml
+++ b/charts/hush-am/templates/_helpers.yaml
@@ -108,7 +108,7 @@ Image path for Spire Agent container.
 {{- $ctx := dict
     "registry" (include "hush-common.imageRegistry" .)
     "repository" .Values.image.spireAgentRepository
-    "tag" (.Values.image.spireAgentTag | default "v0.4.0")
+    "tag" (.Values.image.spireAgentTag | default "v0.14.0")
 -}}
 {{- include "hush-common.buildImagePath" $ctx -}}
 {{- end }}

--- a/charts/hush-am/templates/spireagentdaemonset.yaml
+++ b/charts/hush-am/templates/spireagentdaemonset.yaml
@@ -16,7 +16,7 @@ spec:
 
   template:
     metadata:
-      labels: {{- include "hush-common.labels" . | nindent 8 }}
+      labels: {{- include "hush-common.podLabels" . | nindent 8 }}
         app.kubernetes.io/component: spire-agent
       {{ with .Values.spireAgent.annotations -}}
       annotations: {{- . | nindent 8 }}

--- a/charts/hush-common/templates/_helpers.yaml
+++ b/charts/hush-common/templates/_helpers.yaml
@@ -70,6 +70,20 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*
+Pod template labels: stable across chart releases.
+Excludes helm.sh/chart and app.kubernetes.io/version, which change on
+every release and would needlessly restart pods of workloads whose spec
+did not otherwise change.
+*/}}
+{{- define "hush-common.podLabels" -}}
+{{ include "hush-common.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels -}}
+    {{- toYaml . | nindent 0 }}
+{{- end }}
+{{- end }}
+
+{{/*
 b64dec with error check
 */}}
 {{- define "hush-common.b64decode" -}}


### PR DESCRIPTION
Pinning the spire-agent image tag (HUSH-4693, 1d1a7666a3) did not stop
the spire-agent DaemonSet from rolling on every chart release: the pod
template labels include helm.sh/chart and app.kubernetes.io/version,
which change on every release and alone re-trigger the rollout.

Introduce hush-common.podLabels -- the stable subset of
hush-common.labels (selector labels, managed-by, commonLabels) -- and
use it in the spire-agent pod template. The DaemonSet object keeps the
full label set; only the pods lose the two per-release labels. Nothing
in the charts selects pods by the removed labels.

The upgrade delivering this change restarts spire-agent one last time.
Afterwards the DaemonSet rolls only when its pod spec really changes
(pinned image bump, template or values changes).
