### PR TITLE
HUSH-6008 Bump tools

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,7 +46,7 @@ jobs:
         uses: yokawasa/action-setup-kube-tools@v0.13.5
         with:
           kubectl: "1.31.2"
-          kubeconform: "0.6.7"
+          kubeconform: "0.8.0"
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.8.0
       - name: Lint

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,7 +45,6 @@ jobs:
       - name: Install kube tools
         uses: yokawasa/action-setup-kube-tools@v0.13.5
         with:
-          kubectl: "1.31.2"
           kubeconform: "0.8.0"
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.8.0


### PR DESCRIPTION
- **HUSH-6008 Bump kubeconform from 0.6.7 to 0.8.0**
- **HUSH-6008 Drop unused kubectl from kube-tools install**
