### PR TITLE
HUSH-6413 hush-am: opt-in SPIRE-agent wait and injector failure-strategy knobs

### DIFF
--- a/charts/hush-am/CHANGELOG.md
+++ b/charts/hush-am/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- `admissionController.spireAgentWaitDuration` / `spireAgentWaitStep` to control
+  how long an injected workload waits for the node's SPIRE agent before starting.
+  Unset by default (the injector's built-in 30s timeout, after which the workload
+  starts without its injected secrets if the agent is not ready). Set
+  `spireAgentWaitDuration` to `"-1s"` to wait indefinitely (recommended where
+  nodes scale up, e.g. Karpenter) or to a bounded duration like `"300s"`.
+
 ### Changed
 
 - bump the default spire-agent image to `v0.14.0`. The first upgrade after this

--- a/charts/hush-am/CHANGELOG.md
+++ b/charts/hush-am/CHANGELOG.md
@@ -14,6 +14,10 @@ All notable changes to this project will be documented in this file.
   starts without its injected secrets if the agent is not ready). Set
   `spireAgentWaitDuration` to `"-1s"` to wait indefinitely (recommended where
   nodes scale up, e.g. Karpenter) or to a bounded duration like `"300s"`.
+- `admissionController.injectorFailureStrategy` to choose what happens when the
+  injector cannot fetch a workload's secrets: unset keeps the default
+  (`continue` -- the workload starts without its injected secrets); `"abort"`
+  fails the workload so it never starts without them.
 
 ### Changed
 

--- a/charts/hush-am/ci/injector-failure-strategy-values.yaml
+++ b/charts/hush-am/ci/injector-failure-strategy-values.yaml
@@ -1,0 +1,7 @@
+---
+hushDeployment:
+  token: "ZDE6em9uZTpyZWFsbTpvcmctaWQ6ZGVwbG95bWVudC1pZA=="
+  password: "koko.password"
+
+admissionController:
+  injectorFailureStrategy: "abort"

--- a/charts/hush-am/ci/injector-spire-agent-wait-values.yaml
+++ b/charts/hush-am/ci/injector-spire-agent-wait-values.yaml
@@ -1,0 +1,8 @@
+---
+hushDeployment:
+  token: "ZDE6em9uZTpyZWFsbTpvcmctaWQ6ZGVwbG95bWVudC1pZA=="
+  password: "koko.password"
+
+admissionController:
+  spireAgentWaitDuration: "-1s"
+  spireAgentWaitStep: "10s"

--- a/charts/hush-am/templates/_helpers.yaml
+++ b/charts/hush-am/templates/_helpers.yaml
@@ -934,6 +934,19 @@ Is valid spire log level?
 {{- end }}
 
 {{/*
+Admission controller injector failure strategy (validated; empty when unset)
+*/}}
+{{- define "hush-am.admissionControllerInjectorFailureStrategy" -}}
+{{- with .Values.admissionController.injectorFailureStrategy -}}
+{{- $valid := list "abort" "continue" -}}
+{{- if not (has . $valid) -}}
+{{- fail (printf "'admissionController.injectorFailureStrategy' must be one of %v" $valid) -}}
+{{- end -}}
+{{- . -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Spire Server custom log level
 */}}
 {{- define "hush-am.spireServerLogLevel" -}}

--- a/charts/hush-am/templates/accessmanagerworkload.yaml
+++ b/charts/hush-am/templates/accessmanagerworkload.yaml
@@ -297,6 +297,10 @@ spec:
             - name: ZAZU_SPIRE_AGENT_WAIT_STEP
               value: {{ . | quote }}
             {{- end }}
+            {{- with (include "hush-am.admissionControllerInjectorFailureStrategy" .) }}
+            - name: ZAZU_INJECTOR_FAILURE_STRATEGY
+              value: {{ . | quote }}
+            {{- end }}
         - name: vector
           image: {{ include "hush-am.accessManagerVectorImagePath" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/charts/hush-am/templates/accessmanagerworkload.yaml
+++ b/charts/hush-am/templates/accessmanagerworkload.yaml
@@ -289,6 +289,14 @@ spec:
               value: {{ include "hush-am.admissionControllerBindAddress" . | quote }}
             - name: ZAZU_AWS_ECR_CFG_MODE
               value: {{ include "hush-am.admissionControllerAwcEcrCfgMode" . | quote }}
+            {{- with .Values.admissionController.spireAgentWaitDuration }}
+            - name: ZAZU_SPIRE_AGENT_WAIT_DURATION
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.admissionController.spireAgentWaitStep }}
+            - name: ZAZU_SPIRE_AGENT_WAIT_STEP
+              value: {{ . | quote }}
+            {{- end }}
         - name: vector
           image: {{ include "hush-am.accessManagerVectorImagePath" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/charts/hush-am/values.yaml
+++ b/charts/hush-am/values.yaml
@@ -737,6 +737,13 @@ admissionController:
   spireAgentWaitDuration: ""
   spireAgentWaitStep: ""
 
+  # Failure strategy when the injector cannot fetch a workload's secrets (e.g.
+  # the SPIRE agent is unreachable). Empty uses the injector's built-in default
+  # ("continue": start the workload without its injected secrets). Set to
+  # "abort" to fail the workload instead, so it never starts without its
+  # secrets. Allowed values: "abort", "continue".
+  injectorFailureStrategy: ""
+
   # Default resource requests/limits for Admission Controller
   #
   # Adjusted to cover most cases. Change based on your needs.

--- a/charts/hush-am/values.yaml
+++ b/charts/hush-am/values.yaml
@@ -728,6 +728,15 @@ admissionController:
   # Enable hushinjector verbose mode
   verboseInjector: false
 
+  # How long an injected workload waits for the node's SPIRE agent socket before
+  # giving up, and the interval between connection attempts. Left empty by
+  # default, which uses the injector's built-in 30s timeout -- after which, on a
+  # node whose SPIRE agent is not yet ready, the workload starts without its
+  # injected secrets. Set spireAgentWaitDuration to "-1s" to wait indefinitely,
+  # or to a bounded duration (e.g. "300s").
+  spireAgentWaitDuration: ""
+  spireAgentWaitStep: ""
+
   # Default resource requests/limits for Admission Controller
   #
   # Adjusted to cover most cases. Change based on your needs.


### PR DESCRIPTION
On a freshly provisioned node (e.g. EKS + Karpenter) the SPIRE agent
DaemonSet may not be ready when a user workload lands. The injector then
times out after its built-in 30s and, being fail-open, starts the workload
without its injected secrets.

This adds two opt-in admission-controller knobs, both empty by default so
existing behavior is unchanged:

- `admissionController.spireAgentWaitDuration` / `spireAgentWaitStep` ->
  `ZAZU_SPIRE_AGENT_WAIT_*`: how long an injected workload waits for the
  node's SPIRE agent before starting. Set `spireAgentWaitDuration` to `-1s`
  to wait indefinitely (so the workload starts with its secrets) or to a
  bounded duration. Requires an injector image that reads these env vars
  (HUSH-6413); older images ignore them.

- `admissionController.injectorFailureStrategy` ->
  `ZAZU_INJECTOR_FAILURE_STRATEGY` (chart-validated `abort`/`continue`): set
  to `abort` to fail a workload that cannot fetch its secrets instead of
  starting it without them. Works with the current injector image.

Example:

```yaml
admissionController:
  spireAgentWaitDuration: "-1s"
  injectorFailureStrategy: "abort"
```
