### PR TITLE
HUSH-6518 hush-am: bump the version to 0.19.1

### DIFF
--- a/charts/hush-am/CHANGELOG.md
+++ b/charts/hush-am/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## hush-am 0.19.1 - 2026-07-05
+
+### Changed
+
+- bump `appVersion` from `v0.15.0` to `v0.16.0`. No chart-template changes.
+
 ## hush-am 0.19.0 - 2026-06-25
 
 ### Added

--- a/charts/hush-am/Chart.yaml
+++ b/charts/hush-am/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: hush-am
 description: A Helm chart for Hush Security Access Management platform.
 type: application
-version: 0.19.0
-appVersion: "v0.15.0"
+version: 0.19.1
+appVersion: "v0.16.0"
 home: https://hush.security
 dependencies:
   - name: hush-common


### PR DESCRIPTION
Bump the app version to v0.16.0.

No chart changes, hence patch-level version bump in the chart.
