### PR TITLE
HUSH-6161 hush-am: point the access manager at its secret-store db

### DIFF
--- a/charts/hush-am/templates/_helpers.yaml
+++ b/charts/hush-am/templates/_helpers.yaml
@@ -310,6 +310,13 @@ Acr DB file path
 {{- end }}
 
 {{/*
+Secret Store DB file path
+*/}}
+{{- define "hush-am.secretStoreDbFilePath" -}}
+{{- printf "%s/secretstoredb.sqlite3" (include "hush-am.accessManagerDataDirPath" .) -}}
+{{- end }}
+
+{{/*
 API Controller data directory path
 */}}
 {{- define "hush-am.apiControllerDataDirPath" -}}
@@ -718,6 +725,8 @@ Access Manager envs
   value: {{ include "hush-am.keyDbFilePath" . }}
 - name: MUFASA_ACR_DB_PATH
   value: {{ include "hush-am.acrDbFilePath" . }}
+- name: MUFASA_SECRET_STORE_DB_PATH
+  value: {{ include "hush-am.secretStoreDbFilePath" . }}
 - name: MUFASA_SPIRESERVER_UDS_PATH
   value: {{ include "hush-am.spireServerSocketPath" . }}
 - name: SIMBA_BIND_ADDRESS


### PR DESCRIPTION
The access manager mirrors the deployment's secret-store configuration
into a local SQLite db and builds silos from it; the init container
syncs the mirror and the server reads it at boot, so both consume
MUFASA_SECRET_STORE_DB_PATH. Place the db next to the other access
manager mirrors in the data directory.
