### PR TITLE
HUSH-6546 hush-am: add a PodDisruptionBudget for the access manager

### DIFF
--- a/charts/hush-am/CHANGELOG.md
+++ b/charts/hush-am/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## hush-am 0.20.0 - 2026-07-06
 
 ### Added
 

--- a/charts/hush-am/CHANGELOG.md
+++ b/charts/hush-am/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Added
+
+- add a PodDisruptionBudget for the access manager so that voluntary node
+  disruptions (drain, autoscaler consolidation) evict at most one
+  access-manager pod at a time. Created only when `accessManager.replicas`
+  is greater than 1. Disable with
+  `accessManager.podDisruptionBudget.enabled: false`.
+
 ## hush-am 0.19.1 - 2026-07-05
 
 ### Changed

--- a/charts/hush-am/Chart.yaml
+++ b/charts/hush-am/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hush-am
 description: A Helm chart for Hush Security Access Management platform.
 type: application
-version: 0.19.1
+version: 0.20.0
 appVersion: "v0.16.0"
 home: https://hush.security
 dependencies:

--- a/charts/hush-am/ci/access-manager-pdb-disabled-values.yaml
+++ b/charts/hush-am/ci/access-manager-pdb-disabled-values.yaml
@@ -1,0 +1,9 @@
+---
+accessManager:
+  podDisruptionBudget:
+    enabled: false
+
+secretStore:
+  kind: "awssm"
+  aws:
+    region: "eu-central-1"

--- a/charts/hush-am/ci/access-manager-single-replica-values.yaml
+++ b/charts/hush-am/ci/access-manager-single-replica-values.yaml
@@ -1,0 +1,8 @@
+---
+accessManager:
+  replicas: 1
+
+secretStore:
+  kind: "awssm"
+  aws:
+    region: "eu-central-1"

--- a/charts/hush-am/ci/custom-secretless-manager-port-values.yaml
+++ b/charts/hush-am/ci/custom-secretless-manager-port-values.yaml
@@ -8,5 +8,5 @@ secretStore:
   aws:
     region: "eu-central-1"
 
-manager:
+accessManager:
   port: 60843

--- a/charts/hush-am/ci/statefulset-manager-kind-values.yaml
+++ b/charts/hush-am/ci/statefulset-manager-kind-values.yaml
@@ -8,5 +8,5 @@ secretStore:
   aws:
     region: "eu-central-1"
 
-manager:
+accessManager:
   kind: statefulset

--- a/charts/hush-am/ci/volume-claims-values.yaml
+++ b/charts/hush-am/ci/volume-claims-values.yaml
@@ -8,8 +8,9 @@ secretStore:
   aws:
     region: "eu-central-1"
 
-manager:
-  volume:
+accessManager:
+  kind: statefulset
+  dataVolumeClaim:
     size: 17Gi
     storageClassName: "standard"
     selector:

--- a/charts/hush-am/templates/_helpers.yaml
+++ b/charts/hush-am/templates/_helpers.yaml
@@ -787,7 +787,7 @@ Access Manager Kind
 {{- $kind := and .Values.accessManager .Values.accessManager.kind -}}
 {{- $validKinds := list "deployment" "statefulset" -}}
 {{- if not (has $kind $validKinds) -}}
-    {{- fail (printf "'manager.kind' must be one of %v" $validKinds) -}}
+    {{- fail (printf "'accessManager.kind' must be one of %v" $validKinds) -}}
 {{- end -}}
 {{- $kind -}}
 {{- end }}

--- a/charts/hush-am/templates/accessmanagerpoddisruptionbudget.yaml
+++ b/charts/hush-am/templates/accessmanagerpoddisruptionbudget.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.accessManager.podDisruptionBudget.enabled (gt (int .Values.accessManager.replicas) 1) -}}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "hush-am.accessManagerFullName" . }}
+  labels: {{- include "hush-common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: access-manager-pod-disruption-budget
+  namespace: {{ include "hush-common.namespace" . }}
+spec:
+  maxUnavailable: 1
+  unhealthyPodEvictionPolicy: AlwaysAllow
+  selector:
+    matchLabels: {{- include "hush-common.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: access-manager
+{{- end }}

--- a/charts/hush-am/values.yaml
+++ b/charts/hush-am/values.yaml
@@ -403,7 +403,7 @@ accessManager:
     custom: []
 
   # Data volume claim configuration.
-  # This is ignored when 'manager.kind' is 'deployment'.
+  # This is ignored when 'accessManager.kind' is 'deployment'.
   dataVolumeClaim:
     # Size of the volume claim
     size: 8Gi

--- a/charts/hush-am/values.yaml
+++ b/charts/hush-am/values.yaml
@@ -312,6 +312,13 @@ accessManager:
   # Number of manager replicas
   replicas: 2
 
+  # Pod disruption budget for the access manager.
+  #
+  # When enabled, and 'replicas' is greater than 1, limits voluntary
+  # disruptions (e.g. node drain) to one access-manager pod at a time.
+  podDisruptionBudget:
+    enabled: true
+
   # Readiness probe parameters for access-manager.
   # Changes must be coordinated with Hush support team.
   readinessProbe:

--- a/tests/tests/test_ci_values.py
+++ b/tests/tests/test_ci_values.py
@@ -1,0 +1,46 @@
+import os
+import pytest
+from yaml import CSafeLoader as Loader
+from yaml import load
+
+TOP_DIR = os.environ["TOP_DIR"]
+CHARTS_DIR = os.path.join(TOP_DIR, "charts")
+
+
+def _ci_files():
+    params = []
+    for chart in sorted(os.listdir(CHARTS_DIR)):
+        ci_dir = os.path.join(CHARTS_DIR, chart, "ci")
+        if not os.path.isdir(ci_dir):
+            continue
+        for filename in sorted(os.listdir(ci_dir)):
+            if filename.endswith("-values.yaml"):
+                params.append((chart, filename))
+    return params
+
+
+def _load_yaml(path):
+    with open(path, "r", encoding="utf-8") as f:
+        return load(f, Loader=Loader)
+
+
+def _unknown_paths(values, defaults, path=""):
+    # Sections whose default is an empty map/list (nodeSelector,
+    # annotations, resources, ...) are free-form and not descended into.
+    unknown = []
+    for key, value in values.items():
+        here = f"{path}.{key}" if path else key
+        if key not in defaults:
+            unknown.append(here)
+            continue
+        dflt = defaults[key]
+        if isinstance(value, dict) and isinstance(dflt, dict) and dflt:
+            unknown.extend(_unknown_paths(value, dflt, here))
+    return unknown
+
+
+@pytest.mark.parametrize("chart,filename", _ci_files())
+def test_ci_values_use_known_keys(chart, filename):
+    defaults = _load_yaml(os.path.join(CHARTS_DIR, chart, "values.yaml"))
+    values = _load_yaml(os.path.join(CHARTS_DIR, chart, "ci", filename)) or {}
+    assert _unknown_paths(values, defaults) == []


### PR DESCRIPTION
Add a PodDisruptionBudget for the access manager so that voluntary node
disruptions (drain, autoscaler consolidation) evict at most one
access-manager pod at a time.

- `maxUnavailable: 1`, `unhealthyPodEvictionPolicy: AlwaysAllow`
- created only when `accessManager.replicas` is greater than 1
- toggle via `accessManager.podDisruptionBudget.enabled` (default `true`)
- release hush-am 0.20.0
