### PR TITLE
HUSH-6161 hush-am: scope k8s secret write RBAC to configured namespaces

### DIFF
--- a/charts/hush-am/CHANGELOG.md
+++ b/charts/hush-am/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- `secretStore.k8s.additionalNamespaces` to grant the access manager write
+  access to secrets in namespaces other than its own, for k8s secret stores
+  placed there via the Secret Store API. The grant is scoped to each listed
+  namespace (which must already exist), never cluster-wide. Example:
+
+  ```yaml
+  secretStore:
+    k8s:
+      additionalNamespaces:
+        - team-a
+        - team-b
+  ```
+
 ### Changed
 
 - the access manager no longer gets cluster-wide write access to Secrets. When

--- a/charts/hush-am/CHANGELOG.md
+++ b/charts/hush-am/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Changed
+
+- the access manager no longer gets cluster-wide write access to Secrets. When
+  the k8s secret store uses a namespace other than its own, write access is
+  granted only in that namespace (a namespaced RoleBinding). Cluster-wide
+  access to Secrets is now read-only, as needed for reading image-pull secrets.
+
 ## hush-am 0.20.0 - 2026-07-06
 
 ### Added

--- a/charts/hush-am/ci/k8s-silo-additional-namespaces-values.yaml
+++ b/charts/hush-am/ci/k8s-silo-additional-namespaces-values.yaml
@@ -1,0 +1,11 @@
+---
+hushDeployment:
+  token: "ZDE6em9uZTpyZWFsbTpvcmctaWQ6ZGVwbG95bWVudC1pZA=="
+  password: "koko.password"
+
+secretStore:
+  kind: "kubesecrets"
+  k8s:
+    additionalNamespaces:
+      - team-a
+      - team-b

--- a/charts/hush-am/templates/_helpers.yaml
+++ b/charts/hush-am/templates/_helpers.yaml
@@ -478,14 +478,16 @@ true
 
 {{/*
 Namespaces (space-separated) needing a scoped RoleBinding for k8s secret
-writes: the k8s Silo namespace when it is not the install namespace. The
-install namespace is already covered by the access-manager Role.
+writes: the configured additional namespaces plus the k8s Silo namespace
+when it is not the install namespace. The install namespace is already
+covered by the access-manager Role, so it is dropped.
 */}}
 {{- define "hush-am.secretWriteNamespaces" -}}
-{{- $namespaces := list -}}
+{{- $namespaces := .Values.secretStore.k8s.additionalNamespaces | default list -}}
 {{- if not (include "hush-am.kubeSiloUsesSelfNamespace" .) -}}
-  {{- $namespaces = append $namespaces (include "hush-am.kubeSiloNamespace" .) -}}
+  {{- $namespaces = concat $namespaces (list (include "hush-am.kubeSiloNamespace" .)) -}}
 {{- end -}}
+{{- $namespaces = without ($namespaces | uniq) (include "hush-common.namespace" .) -}}
 {{- $namespaces | join " " -}}
 {{- end }}
 

--- a/charts/hush-am/templates/_helpers.yaml
+++ b/charts/hush-am/templates/_helpers.yaml
@@ -477,6 +477,19 @@ true
 {{- end }}
 
 {{/*
+Namespaces (space-separated) needing a scoped RoleBinding for k8s secret
+writes: the k8s Silo namespace when it is not the install namespace. The
+install namespace is already covered by the access-manager Role.
+*/}}
+{{- define "hush-am.secretWriteNamespaces" -}}
+{{- $namespaces := list -}}
+{{- if not (include "hush-am.kubeSiloUsesSelfNamespace" .) -}}
+  {{- $namespaces = append $namespaces (include "hush-am.kubeSiloNamespace" .) -}}
+{{- end -}}
+{{- $namespaces | join " " -}}
+{{- end }}
+
+{{/*
 Parse AWS Access Token parameters
 */}}
 {{- define "hush-am.awsAccessToken" -}}

--- a/charts/hush-am/templates/accessmanagerserviceaccount.yaml
+++ b/charts/hush-am/templates/accessmanagerserviceaccount.yaml
@@ -104,3 +104,24 @@ roleRef:
   name: {{ include "hush-am.diagFullName" . }}-lease
   apiGroup: rbac.authorization.k8s.io
 {{- end }}
+{{- $writeNamespaces := include "hush-am.secretWriteNamespaces" . }}
+{{- if $writeNamespaces }}
+{{- range $ns := splitList " " $writeNamespaces }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "hush-am.accessManagerFullName" $ }}-secret-writer-role-binding
+  namespace: {{ $ns }}
+  labels: {{- include "hush-common.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: access-manager-secret-writer-role-binding
+subjects:
+- kind: ServiceAccount
+  name: {{ include "hush-am.accessManagerFullName" $ }}
+  namespace: {{ include "hush-common.namespace" $ }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "hush-am.accessManagerFullName" $ }}-secret-writer-cluster-role
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
+{{- end }}

--- a/charts/hush-am/templates/clusterrole.yaml
+++ b/charts/hush-am/templates/clusterrole.yaml
@@ -23,10 +23,20 @@ rules:
   - apiGroups: [""]
     resources:
       - secrets
-    {{- if (include "hush-am.kubeSiloUsesSelfNamespace" .) }}
     verbs:
       - get
       - watch
-    {{- else }}
+{{- if (include "hush-am.secretWriteNamespaces" .) }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "hush-am.accessManagerFullName" . }}-secret-writer-cluster-role
+  labels: {{- include "hush-common.labels" . | nindent 4 }}
+    app.kubernetes.io/component: access-manager-secret-writer-cluster-role
+rules:
+  - apiGroups: [""]
+    resources:
+      - secrets
     verbs: ["*"]
-    {{- end }}
+{{- end }}

--- a/charts/hush-am/values.yaml
+++ b/charts/hush-am/values.yaml
@@ -251,6 +251,13 @@ secretStore:
     # If not specified, the namespace where the chart is installed is used.
     namespace: ""
 
+    # Additional namespaces where the access manager may write secrets, for
+    # k8s secret stores that the Secret Store API places outside the silo's
+    # own namespace. Each namespace must already exist; the access manager
+    # is granted write access only in these namespaces (a scoped RoleBinding
+    # each), never cluster-wide.
+    additionalNamespaces: []
+
 # Container registry configuration.
 # This affects the way Hush Access Management platform accesses workload container images'
 # manifest to update injector command accordingly


### PR DESCRIPTION
Tighten the access manager's Secret RBAC and make cross-namespace k8s
secret stores grantable per namespace instead of cluster-wide.

Today the access manager is granted cluster-wide write on Secrets
(`secrets: ["*"]` on a cluster-bound ClusterRole) whenever the k8s silo
uses a namespace other than its own -- far more than it needs to write
secrets in that one namespace. This PR scopes that down and adds a
supported way to extend it to the namespaces future k8s secret stores
will use.

- Scope the write grant to the silo's namespace. The cluster-wide
  ClusterRole keeps only `secrets: get, watch` (needed for reading
  image-pull secrets); write access is granted through a dedicated
  `-secret-writer-cluster-role` bound by a namespaced RoleBinding in
  each target namespace. The install namespace is unchanged -- it is
  already covered by the access-manager Role, so self-namespace
  deployments render no new RBAC.
- Add `secretStore.k8s.additionalNamespaces`: a list of namespaces
  (besides the silo's own) where the access manager may write secrets,
  for k8s secret stores that the Secret Store API places there. Each
  gets its own scoped RoleBinding; the grant is never cluster-wide.
  Namespaces are unioned with the silo namespace, deduped, and the
  install namespace is dropped.

Behavior change: an install that set `secretStore.k8s.namespace` to a
non-install namespace previously gave the access manager cluster-wide
secret write; it now gets write only in that namespace. Reads are
unaffected. Listed namespaces must already exist (a RoleBinding cannot
target a missing namespace).

Prefix-level scoping (only the silo's own secrets) is intentionally not
attempted: Kubernetes RBAC cannot match resource names by prefix and
cannot name-restrict `create` at all, so the namespace is the tightest
enforceable boundary. Operators wanting per-store isolation should give
each store its own namespace.
