### PR TITLE
HUSH-5564 hush-am: increase diag retry interval

### DIFF
--- a/charts/hush-am/values.yaml
+++ b/charts/hush-am/values.yaml
@@ -870,7 +870,7 @@ diagnostics:
   # Cadence between diagnostic runs while one or more checks fail. The
   # daemon retries at this (shorter) interval until all checks pass, then
   # returns to the normal interval.
-  retryInterval: "5m"
+  retryInterval: "15m"
 
   # Per-check timeout passed to the diagnostics binary.
   perCheckTimeout: "30s"


### PR DESCRIPTION
After running for a few weeks on customer's environments, it seems that
5 minutes is not enough to avoid reporting on transient errors,
especially ones that happens when pods start.
